### PR TITLE
Fix Filesystem and Editor compatibility for CustomTkinter migration

### DIFF
--- a/src/views/app_layers.py
+++ b/src/views/app_layers.py
@@ -105,10 +105,13 @@ def create_content_file_window():
         # Allow event to continue for proper scrollbar update
         return
 
+    # Determine the actual text widget to bind events to (internal _textbox for CTkTextbox)
+    target_widget = getattr(script_text, "_textbox", script_text)
+
     # Bind mouse wheel events
-    script_text.bind("<MouseWheel>", on_mousewheel)  # Windows
-    script_text.bind("<Button-4>", on_mousewheel)  # Linux up
-    script_text.bind("<Button-5>", on_mousewheel)  # Linux down
+    target_widget.bind("<MouseWheel>", on_mousewheel)  # Windows
+    target_widget.bind("<Button-4>", on_mousewheel)  # Linux up
+    target_widget.bind("<Button-5>", on_mousewheel)  # Linux down
 
     # Handle keyboard navigation that may affect scrolling
     def on_key_scroll(event):
@@ -117,13 +120,13 @@ def create_content_file_window():
 
     # Bind key navigation events
     for key in ("<Key-Up>", "<Key-Down>", "<Key-Prior>", "<Key-Next>", "<Key-Home>", "<Key-End>"):
-        script_text.bind(key, on_key_scroll, add="+")
+        target_widget.bind(key, on_key_scroll, add="+")
 
     # Handle text widget resize
     def on_text_configure(event):
         root.after(10, line_numbers.redraw)
 
-    script_text.bind("<Configure>", on_text_configure, add="+")
+    target_widget.bind("<Configure>", on_text_configure, add="+")
 
     def show_context_menu(event):
         context_menu = Menu(root, tearoff=0)
@@ -185,8 +188,8 @@ def create_content_file_window():
         return "break"
 
     # Bind the scroll_lines functions
-    script_text.bind("<Control-Up>", scroll_lines_up)
-    script_text.bind("<Control-Down>", scroll_lines_down)
+    target_widget.bind("<Control-Up>", scroll_lines_up)
+    target_widget.bind("<Control-Down>", scroll_lines_down)
 
     # Show changes in text zone when line numbers width changes
     def show_changes_in_text_zone(event=None):
@@ -199,8 +202,8 @@ def create_content_file_window():
 
     script_text.configure()
 
-    script_text.bind("<Button-3>", show_context_menu)
-    script_text.bind("<Key>", on_text_change)
+    target_widget.bind("<Button-3>", show_context_menu)
+    target_widget.bind("<Key>", on_text_change)
 
     # Additional debugging for manual scrolling
     def scroll_lines_up(event):
@@ -216,8 +219,8 @@ def create_content_file_window():
         return "break"
 
     # Bind the debug scroll functions
-    script_text.bind("<Control-Up>", scroll_lines_up)
-    script_text.bind("<Control-Down>", scroll_lines_down)
+    target_widget.bind("<Control-Up>", scroll_lines_up)
+    target_widget.bind("<Control-Down>", scroll_lines_down)
 
     # Ensure the line numbers are drawn initially
     root.after(100, line_numbers.redraw)

--- a/src/views/tree_functions.py
+++ b/src/views/tree_functions.py
@@ -53,8 +53,9 @@ def update_tree(path):
     """
     for item in tree.get_children():
         tree.delete(item)
-    abspath = os.path.abspath(path)
-    root_node = tree.insert("", "end", text=abspath, values=(abspath), open=True)
+    # Use forward slashes for better Tcl/Tk compatibility and normalize path
+    abspath = os.path.abspath(path).replace('\\', '/')
+    root_node = tree.insert("", "end", text=abspath, values=(abspath,), open=True)
     populate_tree(root_node, abspath)
 
 
@@ -69,12 +70,17 @@ def populate_tree(parent, path):
     Returns:
         None: Description of return value.
     """
-    for item in os.listdir(path):
-        if item != ".git" and item != ".idea":
-            abspath = os.path.join(path, item)
-            node = tree.insert(parent, "end", text=item, values=(abspath), open=False)
-            if os.path.isdir(abspath):
-                tree.insert(node, "end")
+    # Ensure path uses forward slashes
+    path = path.replace('\\', '/')
+    try:
+        for item in os.listdir(path):
+            if item != ".git" and item != ".idea":
+                abspath = os.path.join(path, item).replace('\\', '/')
+                node = tree.insert(parent, "end", text=item, values=(abspath,), open=False)
+                if os.path.isdir(abspath):
+                    tree.insert(node, "end")
+    except Exception as e:
+        print(f"Error populating tree at {path}: {e}")
 
 
 def item_opened(event):

--- a/src/views/ui_elements.py
+++ b/src/views/ui_elements.py
@@ -131,7 +131,8 @@ class Tooltip:
 class LineNumberCanvas(Canvas):
     def __init__(self, text_widget, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.text_widget = text_widget
+        # Handle CTkTextbox by getting its internal _textbox
+        self.text_widget = getattr(text_widget, "_textbox", text_widget)
         self._is_redrawing = False
 
         # Improve event bindings


### PR DESCRIPTION
He realizado un análisis profundo de los problemas reportados tras la migración a CustomTkinter. Los fallos se debían a dos causas principales:

1. **Corrupción de rutas en el Treeview:** Al usar Windows, las rutas con backslashes (como `\r` de `\runescript`) eran interpretadas por el motor Tcl como caracteres de escape. He corregido esto normalizando las rutas con barras hacia adelante (`/`) y asegurando que se pasen como tuplas explícitas al Treeview. Esto restaura la capacidad de abrir archivos y expandir carpetas.

2. **Desconexión de eventos en el Editor:** Al cambiar a `CTkTextbox`, los bindings aplicados al wrapper de CustomTkinter no se propagaban correctamente al widget de texto real. He redirigido estos bindings (scroll, teclado, click derecho) y la lógica de los números de línea al componente interno `._textbox`.

Con estos cambios, el explorador de archivos vuelve a ser funcional, los archivos se abren correctamente al hacer doble click y la sincronización de los números de línea y el scroll queda restaurada.

---
*PR created automatically by Jules for task [4683954230342967490](https://jules.google.com/task/4683954230342967490) started by @Axlfc*