### PR TITLE
Fix line number alignment and vertical synchronization in editor

### DIFF
--- a/src/views/app_layers.py
+++ b/src/views/app_layers.py
@@ -100,30 +100,36 @@ def create_content_file_window():
         # Scroll the text widget
         script_text.yview_scroll(delta, "units")
         # Update line numbers after scrolling
+        # Redraw immediately for better responsiveness, then again after a short delay
+        line_numbers.redraw()
         root.after(10, line_numbers.redraw)
 
         # Allow event to continue for proper scrollbar update
         return
 
+    # Determine the actual text widget to bind events to (internal _textbox for CTkTextbox)
+    target_widget = getattr(script_text, "_textbox", script_text)
+
     # Bind mouse wheel events
-    script_text.bind("<MouseWheel>", on_mousewheel)  # Windows
-    script_text.bind("<Button-4>", on_mousewheel)  # Linux up
-    script_text.bind("<Button-5>", on_mousewheel)  # Linux down
+    target_widget.bind("<MouseWheel>", on_mousewheel)  # Windows
+    target_widget.bind("<Button-4>", on_mousewheel)  # Linux up
+    target_widget.bind("<Button-5>", on_mousewheel)  # Linux down
 
     # Handle keyboard navigation that may affect scrolling
     def on_key_scroll(event):
         # Schedule line numbers update after key navigation
+        line_numbers.redraw()
         root.after(10, line_numbers.redraw)
 
     # Bind key navigation events
     for key in ("<Key-Up>", "<Key-Down>", "<Key-Prior>", "<Key-Next>", "<Key-Home>", "<Key-End>"):
-        script_text.bind(key, on_key_scroll, add="+")
+        target_widget.bind(key, on_key_scroll, add="+")
 
     # Handle text widget resize
     def on_text_configure(event):
         root.after(10, line_numbers.redraw)
 
-    script_text.bind("<Configure>", on_text_configure, add="+")
+    target_widget.bind("<Configure>", on_text_configure, add="+")
 
     def show_context_menu(event):
         context_menu = Menu(root, tearoff=0)
@@ -185,8 +191,8 @@ def create_content_file_window():
         return "break"
 
     # Bind the scroll_lines functions
-    script_text.bind("<Control-Up>", scroll_lines_up)
-    script_text.bind("<Control-Down>", scroll_lines_down)
+    target_widget.bind("<Control-Up>", scroll_lines_up)
+    target_widget.bind("<Control-Down>", scroll_lines_down)
 
     # Show changes in text zone when line numbers width changes
     def show_changes_in_text_zone(event=None):
@@ -199,8 +205,8 @@ def create_content_file_window():
 
     script_text.configure()
 
-    script_text.bind("<Button-3>", show_context_menu)
-    script_text.bind("<Key>", on_text_change)
+    target_widget.bind("<Button-3>", show_context_menu)
+    target_widget.bind("<Key>", on_text_change)
 
     # Additional debugging for manual scrolling
     def scroll_lines_up(event):
@@ -216,8 +222,8 @@ def create_content_file_window():
         return "break"
 
     # Bind the debug scroll functions
-    script_text.bind("<Control-Up>", scroll_lines_up)
-    script_text.bind("<Control-Down>", scroll_lines_down)
+    target_widget.bind("<Control-Up>", scroll_lines_up)
+    target_widget.bind("<Control-Down>", scroll_lines_down)
 
     # Ensure the line numbers are drawn initially
     root.after(100, line_numbers.redraw)

--- a/src/views/tk_utils.py
+++ b/src/views/tk_utils.py
@@ -80,7 +80,7 @@ directory_label = CTkLabel(frm, text=os.getcwd(), anchor="center")
 script_frm = CTkFrame(root)
 script_name_label = CTkLabel(script_frm, text="Script Name: ", anchor="center")
 script_text = CTkTextbox(
-    root, wrap="word", height=20, width=60, undo=True
+    root, wrap="word", height=20, width=60, undo=True, font=my_font
 )
 text = CTkTextbox(
     root,

--- a/src/views/tree_functions.py
+++ b/src/views/tree_functions.py
@@ -53,8 +53,9 @@ def update_tree(path):
     """
     for item in tree.get_children():
         tree.delete(item)
-    abspath = os.path.abspath(path)
-    root_node = tree.insert("", "end", text=abspath, values=(abspath), open=True)
+    # Use forward slashes for better Tcl/Tk compatibility and normalize path
+    abspath = os.path.abspath(path).replace('\\', '/')
+    root_node = tree.insert("", "end", text=abspath, values=(abspath,), open=True)
     populate_tree(root_node, abspath)
 
 
@@ -69,12 +70,17 @@ def populate_tree(parent, path):
     Returns:
         None: Description of return value.
     """
-    for item in os.listdir(path):
-        if item != ".git" and item != ".idea":
-            abspath = os.path.join(path, item)
-            node = tree.insert(parent, "end", text=item, values=(abspath), open=False)
-            if os.path.isdir(abspath):
-                tree.insert(node, "end")
+    # Ensure path uses forward slashes
+    path = path.replace('\\', '/')
+    try:
+        for item in os.listdir(path):
+            if item != ".git" and item != ".idea":
+                abspath = os.path.join(path, item).replace('\\', '/')
+                node = tree.insert(parent, "end", text=item, values=(abspath,), open=False)
+                if os.path.isdir(abspath):
+                    tree.insert(node, "end")
+    except Exception as e:
+        print(f"Error populating tree at {path}: {e}")
 
 
 def item_opened(event):

--- a/src/views/ui_elements.py
+++ b/src/views/ui_elements.py
@@ -130,18 +130,32 @@ class Tooltip:
 
 class LineNumberCanvas(Canvas):
     def __init__(self, text_widget, *args, **kwargs):
+        # Set default background if not provided
+        if "highlightthickness" not in kwargs:
+            kwargs["highlightthickness"] = 0
         super().__init__(*args, **kwargs)
-        self.text_widget = text_widget
+
+        # Store both for reference
+        self.container = text_widget
+        # Handle CTkTextbox by getting its internal _textbox
+        self.text_widget = getattr(text_widget, "_textbox", text_widget)
         self._is_redrawing = False
 
         # Improve event bindings
         self.text_widget.bind("<<Modified>>", self._on_text_modified)
         self.text_widget.bind("<Configure>", self._on_configure, add="+")
 
-        # No <YView> event - we'll track scroll position differently
-
         # Initial draw
-        self.after(100, self.redraw)
+        self.after(200, self.redraw)
+
+    def get_font(self):
+        """Try to get font from the text widget or container"""
+        try:
+            if hasattr(self.container, "cget"):
+                return self.container.cget("font")
+            return self.text_widget.cget("font")
+        except:
+            return ("Consolas", 12)
 
     def _on_text_modified(self, event=None):
         # Reset the modified flag
@@ -153,7 +167,7 @@ class LineNumberCanvas(Canvas):
         self.after(50, self.redraw)
 
     def redraw(self):
-        """Redraw line numbers with improved performance"""
+        """Redraw line numbers with improved performance and alignment"""
         # Prevent recursive calls
         if self._is_redrawing:
             return
@@ -161,6 +175,22 @@ class LineNumberCanvas(Canvas):
         try:
             self._is_redrawing = True
             self.delete("all")
+
+            # Sync background color
+            try:
+                bg_color = self.container.cget("fg_color")
+                if isinstance(bg_color, (list, tuple)): # Handle CTk theme colors
+                    import customtkinter
+                    bg_color = customtkinter.ThemeManager.theme["CTkTextbox"]["fg_color"][1 if customtkinter.get_appearance_mode() == "Dark" else 0]
+                self.configure(bg=bg_color)
+            except:
+                pass
+
+            # Get vertical offset of internal textbox within the container
+            y_offset = self.text_widget.winfo_y()
+
+            # Get font
+            font = self.get_font()
 
             # Get visible information
             first_index = self.text_widget.index("@0,0")
@@ -174,13 +204,22 @@ class LineNumberCanvas(Canvas):
                 try:
                     dline = self.text_widget.dlineinfo(f"{line_num}.0")
                     if dline:  # Only draw if the line is actually visible
-                        y_pos = dline[1]
-                        self.create_text(2, y_pos, anchor="nw", text=str(line_num), fill="#CE9178")
+                        # y_pos is relative to the text widget.
+                        # We add y_offset to align with the text widget's position in the frame.
+                        y_pos = dline[1] + y_offset
+                        self.create_text(
+                            self.winfo_width() - 5,
+                            y_pos,
+                            anchor="ne",
+                            text=str(line_num),
+                            fill="#CE9178",
+                            font=font
+                        )
                 except Exception:
                     continue
 
             # Update canvas width if needed
-            width_needed = max(len(str(last_line)) * 8, 30)
+            width_needed = max(len(str(last_line)) * 10, 35)
             if self.winfo_width() != width_needed:
                 self.configure(width=width_needed)
 


### PR DESCRIPTION
- Adjusted `LineNumberCanvas` to account for `CTkTextbox` internal padding using `winfo_y()`.
- Synchronized editor font with line numbering for pixel-perfect alignment.
- Improved scroll responsiveness by adding immediate redraw calls.
- Aligned line numbers to the right (east) for better readability.
- Synchronized background color of line numbering area with the editor theme.