### PR TITLE
Fix incorrect change detection and centralize editor state

### DIFF
--- a/src/controllers/file_operations.py
+++ b/src/controllers/file_operations.py
@@ -21,9 +21,7 @@ from src.views.tk_utils import (
     script_text,
     root,
     menu,
-    is_modified,
-    file_name,
-    last_saved_content)
+    editor_state)
 from src.views.ui_elements import LineNumberCanvas
 
 file_types = [
@@ -52,18 +50,16 @@ file_types = [
 
 
 def open_file(file_path):
-    global is_modified, file_name, last_saved_content
     if not prompt_save_changes():
         return
     print("file_operations.py/open_file IS CALLED!")
-    last_saved_content = ""
-    file_name = file_path
+    editor_state.file_name = file_path
     directory_path = os.path.dirname(file_path)
     directory_label.configure(text=f"{directory_path}")
     write_config_parameter(
         "options.file_management.current_file_directory", directory_path
     )
-    write_config_parameter("options.file_management.last_opened_script", file_name)
+    write_config_parameter("options.file_management.last_opened_script", editor_state.file_name)
     script_name_label.configure(
         text=f"{localization_data['save_changes']} in {os.path.basename(file_path)}"
     )
@@ -78,14 +74,29 @@ def open_file(file_path):
     else:
         with open(file_path, "r", encoding="utf-8", errors="replace") as file:
             script_content = file.read()
+    # Reset internal modified flag during loading
+    try:
+        target_widget = getattr(script_text, "_textbox", script_text)
+        target_widget.edit_modified(False)
+    except Exception:
+        pass
+
     script_text.delete("1.0", END)
     script_text.insert("1.0", script_content)
+
     print("SAVING FILE CONTENT HERE TO LAST_SAVED_CONTENT")
-    last_saved_content = script_content
+    editor_state.update_original_content(script_content)
+
+    # Ensure the widget's internal modified flag is reset AFTER insertion
+    try:
+        target_widget = getattr(script_text, "_textbox", script_text)
+        target_widget.edit_modified(False)
+    except Exception:
+        pass
+
     ext = os.path.splitext(file_path)[1]
     print("EXT of Opened File IS:\t", ext)
     update_menu_based_on_extension(ext, directory_path)
-    is_modified = False
     update_title()
 
     # We need to trigger a redraw of the line numbers and adjust text position
@@ -166,7 +177,7 @@ def update_menu_based_on_extension(ext, directory_path):
 
 def open_script(event=None):
     print("OPEN SCRIPT IS CALLED!")
-    if is_modified:
+    if editor_state.is_modified:
         response = messagebox.askyesnocancel(
             localization_data["save_changes"], localization_data["save_confirmation"]
         )
@@ -184,10 +195,9 @@ def open_script(event=None):
             directory_label.cget("text"))
 
 def update_title():
-    global is_modified
-    print("RENAME MAIN WINDOW TRIGGERED, IS MODIFIED?", is_modified)
-    title = os.path.basename(file_name) if file_name else localization_data["untitled"]
-    if is_modified:
+    print("RENAME MAIN WINDOW TRIGGERED, IS MODIFIED?", editor_state.is_modified)
+    title = os.path.basename(editor_state.file_name) if editor_state.file_name else localization_data["untitled"]
+    if editor_state.is_modified:
         root.title(f"*{title} - {localization_data['scripts_editor']}")
     else:
         root.title(f"{title} - {localization_data['scripts_editor']}")
@@ -195,41 +205,51 @@ def update_title():
 
 
 def on_text_change(event=None):
-    global is_modified, last_saved_content
+    # This might be triggered by <<Modified>> event
+    try:
+        target_widget = getattr(script_text, "_textbox", script_text)
+        # If it was a real modification according to the widget
+        if not target_widget.edit_modified():
+            return
+    except Exception:
+        pass
+
     print("on_text_change triggered")
-    current_content = script_text.get("1.0", END)
-    if current_content != last_saved_content:
-        print("Content has been modified.")
-        if not is_modified:
-            is_modified = True
-            update_title()
-    else:
-        print("No changes detected.")
-        if not is_modified:
-            is_modified = False
-            update_title()
+    current_content = script_text.get("1.0", "end-1c")
+    was_modified = editor_state.is_modified
+    is_now_modified = editor_state.check_modified(current_content)
+
+    if was_modified != is_now_modified:
+        update_title()
+
+    # Reset the internal modified flag so we can receive the event again
+    try:
+        target_widget = getattr(script_text, "_textbox", script_text)
+        target_widget.edit_modified(False)
+    except Exception:
+        pass
 
 
 def prompt_save_changes():
-    if is_modified:
+    if editor_state.is_modified:
         response = messagebox.askyesnocancel(
             "Save Changes", "You have unsaved changes. Would you like to save them?"
         )
         if response is None:
             return False
         elif response:
-            save_file()
+            save_script()
     return True
 
 
 def save():
-    global is_modified, file_name
-    if not file_name or file_name == "Untitled":
+    if not editor_state.file_name or editor_state.file_name == "Untitled":
         return save_as()
     try:
-        with open(file_name, "w", encoding="utf-8") as file:
-            file.write(script_text.get("1.0", "end-1c"))
-            is_modified = False
+        content = script_text.get("1.0", "end-1c")
+        with open(editor_state.file_name, "w", encoding="utf-8") as file:
+            file.write(content)
+            editor_state.update_original_content(content)
             update_title()
             messagebox.showinfo("Save", "File saved successfully!")
             return True
@@ -243,14 +263,12 @@ def save_as():
     """
         Opens a 'Save As' dialog to save the current file with a specified name.
     """
-    global file_name
-    global is_modified
     new_file_name = filedialog.asksaveasfilename(
         defaultextension=".*", filetypes=file_types
     )
     if not new_file_name:
         return False
-    file_name = new_file_name
+    editor_state.file_name = new_file_name
     save()
     update_script_name_label(new_file_name)
     update_title()
@@ -268,32 +286,30 @@ def save_file(file_name, content):
 
 
 def save_script(event=None):
-    global file_name, is_modified
-    if not file_name or file_name == "Untitled":
+    if not editor_state.file_name or editor_state.file_name == "Untitled":
         print("Saving new script...")
         save_as_new_script()
     else:
         print("Saving existing script...")
         content = script_text.get("1.0", "end-1c")
         try:
-            with open(file_name, "w", encoding="utf-8") as file:
+            with open(editor_state.file_name, "w", encoding="utf-8") as file:
                 file.write(content)
-            is_modified = False
+            editor_state.update_original_content(content)
             update_title()
-            update_script_name_label(file_name)
+            update_script_name_label(editor_state.file_name)
             messagebox.showinfo("Save", "File saved successfully!")
         except Exception as e:
             messagebox.showerror("Save Error", f"An error occurred while saving: {e}")
 
 
 def save_as_new_script(event=None):
-    global file_name, is_modified
     new_file_name = filedialog.asksaveasfilename(
         defaultextension=".*", filetypes=file_types
     )
     if not new_file_name:
         return
-    file_name = new_file_name
+    editor_state.file_name = new_file_name
     save_script()
 
 
@@ -304,8 +320,7 @@ def update_script_name_label(file_path):
 
 
 def new(event=None):
-    global is_modified
-    if is_modified:
+    if editor_state.is_modified:
         response = messagebox.askyesnocancel(
             localization_data["save_file"],
             localization_data["save_changes_confirmation"])
@@ -316,15 +331,13 @@ def new(event=None):
             return
         elif not response:
             clear_editor()
-    file_name = ""
+    editor_state.file_name = ""
     clear_editor()
 
 
 def clear_editor():
-    global file_name
-    global is_modified
     script_text.delete("1.0", "end")
-    file_name = ""
-    is_modified = False
+    editor_state.file_name = ""
+    editor_state.update_original_content("")
     update_title()
 

--- a/src/models/file_operations.py
+++ b/src/models/file_operations.py
@@ -1,6 +1,6 @@
 ﻿from tkinter import messagebox, simpledialog
 import os
-from src.views.tk_utils import root, script_name_label
+from src.views.tk_utils import root, script_name_label, editor_state
 
 
 def validate_time(hour, minute):
@@ -18,8 +18,7 @@ def validate_time(hour, minute):
 
 
 def rename(event=None):
-    global file_name
-    if file_name == "":
+    if editor_state.file_name == "":
         file_path = simpledialog.askstring("Rename", "Enter file path or select a file")
         if not file_path:
             return
@@ -27,14 +26,14 @@ def rename(event=None):
         if not os.path.exists(file_path):
             messagebox.showerror("Error", "File does not exist")
             return
-        file_name = file_path
-    dir_path, old_name = os.path.split(file_name)
+        editor_state.file_name = file_path
+    dir_path, old_name = os.path.split(editor_state.file_name)
     new_name = simpledialog.askstring("Rename", "Enter new name")
     try:
         new_path = os.path.join(dir_path, new_name)
-        os.rename(file_name, new_path)
-        file_name = new_path
-        root.title(file_name + " - Script Editor")
+        os.rename(editor_state.file_name, new_path)
+        editor_state.file_name = new_path
+        root.title(editor_state.file_name + " - Script Editor")
     except OSError as e:
         messagebox.showerror("Error", f"Failed to rename file: {e}")
 
@@ -47,13 +46,12 @@ def prompt_rename_file():
 
 
 def rename_or_create_file(new_name):
-    global file_name
-    dir_path = os.path.dirname(file_name) if file_name else os.getcwd()
+    dir_path = os.path.dirname(editor_state.file_name) if editor_state.file_name else os.getcwd()
     new_path = os.path.join(dir_path, new_name)
-    if file_name and os.path.exists(file_name):
+    if editor_state.file_name and os.path.exists(editor_state.file_name):
         try:
-            os.rename(file_name, new_path)
-            file_name = new_path
+            os.rename(editor_state.file_name, new_path)
+            editor_state.file_name = new_path
             script_name_label.configure(text=f"File Name: {new_name}")
             messagebox.showinfo(
                 "Rename Successful", f"File has been renamed to {new_name}"
@@ -64,7 +62,7 @@ def rename_or_create_file(new_name):
         try:
             with open(new_path, "w") as new_file:
                 new_file.write("")
-            file_name = new_path
+            editor_state.file_name = new_path
             script_name_label.configure(text=f"File Name: {new_name}")
             messagebox.showinfo(
                 "File Created", f"New file has been created: {new_name}"

--- a/src/models/script_operations.py
+++ b/src/models/script_operations.py
@@ -15,7 +15,8 @@ from src.views.tk_utils import (
     script_name_label,
     entry_arguments_entry,
     directory_label,
-    root, my_font, localization_data
+    root, my_font, localization_data,
+    editor_state
 )
 
 
@@ -110,12 +111,8 @@ def run_script_windows():
     entry_arguments = entry_arguments_entry.get().split()
     generate_stdout = generate_stdin.get()
     generate_stderr = generate_stdin_err.get()
-    file_name_with_prefix = script_name_label.cget("text")
-    file_name = file_name_with_prefix.replace(
-        localization_data["script_name_label"], ""
-    ).strip()
-    current_directory = directory_label.cget("text")
-    file_path = os.path.join(current_directory, file_name)
+    file_path = editor_state.file_name
+    file_name = os.path.basename(file_path) if file_path else "Untitled"
 
     interpreter_path = read_config_parameter("options.project_settings.current_interpreter")
     if not interpreter_path:
@@ -247,22 +244,22 @@ def run_script():
     generate_stderr = generate_stdin_err.get()
     try:
         print("WE ARE IN!!")
-        print(script_name_label.cget("text"))
+        print(editor_state.file_name)
         print("YEAH!!")
         process = subprocess.Popen(
             ["bash"]
-            + [directory_label.cget("text") + "/" + script_name_label.cget("text")]
+            + [editor_state.file_name]
             + arguments.split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         stdout_data, stderr_data = process.communicate()
         if generate_stdout:
-            script_out_name = script_name_label.cget("text") + ".out"
+            script_out_name = editor_state.file_name + ".out"
             print(script_out_name)
             p = open(script_out_name, "w+")
             p.write(stdout_data.decode())
         if generate_stderr:
-            script_err_name = script_name_label.cget("text") + ".err"
+            script_err_name = editor_state.file_name + ".err"
             p = open(script_err_name, "w+")
             p.write(stderr_data.decode())
         messagebox.showinfo("Script Execution", "Script executed successfully.")
@@ -290,19 +287,19 @@ def run_script_with_timeout(timeout_seconds):
     try:
         process = subprocess.Popen(
             ["bash"]
-            + [directory_label.cget("text") + "/" + script_name_label.cget("text")]
+            + [editor_state.file_name]
             + arguments.split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         sleep(timeout_seconds)
         stdout_data, stderr_data = process.communicate()
         if generate_stdout:
-            script_out_name = script_name_label.cget("text") + ".out"
+            script_out_name = editor_state.file_name + ".out"
             print(script_out_name)
             p = open(script_out_name, "w+")
             p.write(stdout_data.decode())
         if generate_stderr:
-            script_err_name = script_name_label.cget("text") + ".err"
+            script_err_name = editor_state.file_name + ".err"
             p = open(script_err_name, "w+")
             p.write(stderr_data.decode())
         messagebox.showinfo("Script Execution", "Script executed successfully.")
@@ -323,9 +320,7 @@ def run_script_once(schedule_time):
     Returns:
     None
     ""\" """
-    script_path = os.path.join(
-        directory_label.cget("text"), script_name_label.cget("text")
-    )
+    script_path = editor_state.file_name
     arguments = entry_arguments_entry.get()
     generate_stdout = generate_stdin.get()
     generate_stderr = generate_stdin_err.get()
@@ -347,10 +342,10 @@ def run_script_once(schedule_time):
     try:
         at_time = f"{hour:02d}:{minute:02d}"
         stdout_redirect = (
-            f">{script_name_label.cget('text')}.out" if generate_stdout else "/dev/null"
+            f">{editor_state.file_name}.out" if generate_stdout else "/dev/null"
         )
         stderr_redirect = (
-            f"2>{script_name_label.cget('text')}.err"
+            f"2>{editor_state.file_name}.err"
             if generate_stderr
             else "/dev/null"
         )
@@ -388,18 +383,12 @@ def run_script_crontab(minute, hour, day, month, day_of_week):
         )
         return
     cron_schedule = f"{minute} {hour} {day} {month} {day_of_week}"
-    script_path = os.path.join(
-        directory_label.cget("text"), script_name_label.cget("text")
-    )
+    script_path = editor_state.file_name
     arguments = entry_arguments_entry.get()
     generate_stdout = generate_stdin.get()
     generate_stderr = generate_stdin_err.get()
-    out_file = os.path.join(
-        directory_label.cget("text"), f"{script_name_label.cget('text')}.out"
-    )
-    err_file = os.path.join(
-        directory_label.cget("text"), f"{script_name_label.cget('text')}.err"
-    )
+    out_file = f"{editor_state.file_name}.out"
+    err_file = f"{editor_state.file_name}.err"
     try:
         stdout_redirect = f">{out_file}" if generate_stdout else "/dev/null"
         stderr_redirect = f"2>{err_file}" if generate_stderr else "/dev/null"
@@ -433,7 +422,7 @@ def see_stdout():
     stdout_window.title("Standard Output (stdout)")
     stdout_text = Text(stdout_window, font=my_font)
     stdout_text.pack()
-    script_out_name = script_name_label.cget("text") + ".out"
+    script_out_name = editor_state.file_name + ".out"
     try:
         with open(script_out_name, "r") as f:
             stdout_text.insert("1.0", f.read())
@@ -458,7 +447,7 @@ def see_stderr():
     stderr_window.title("Standard Error (stderr)")
     stderr_text = Text(stderr_window, font=my_font)
     stderr_text.pack()
-    script_err_name = script_name_label.cget("text") + ".err"
+    script_err_name = editor_state.file_name + ".err"
     try:
         with open(script_err_name, "r") as f:
             stderr_text.insert("1.0", f.read())

--- a/src/views/app_layers.py
+++ b/src/views/app_layers.py
@@ -75,7 +75,7 @@ def create_filesystem_window():
 
 
 def create_content_file_window():
-    global is_modified, line_numbers
+    global line_numbers
 
     # Create the line numbers canvas
     line_numbers = LineNumberCanvas(script_text, width=30)
@@ -206,7 +206,7 @@ def create_content_file_window():
     script_text.configure()
 
     target_widget.bind("<Button-3>", show_context_menu)
-    target_widget.bind("<Key>", on_text_change)
+    target_widget.bind("<<Modified>>", on_text_change)
 
     # Additional debugging for manual scrolling
     def scroll_lines_up(event):

--- a/src/views/tk_utils.py
+++ b/src/views/tk_utils.py
@@ -43,10 +43,33 @@ def configure_app():
 
 SIMILARITY_THRESHOLD = 0.8
 
+
+class EditorState:
+    def __init__(self):
+        self.file_name = ""
+        self.last_saved_content = ""
+        self.is_modified = False
+
+    def normalize(self, content):
+        if content is None:
+            return ""
+        # Remove trailing newlines for comparison
+        return content.rstrip('\n')
+
+    def update_original_content(self, content):
+        self.last_saved_content = self.normalize(content)
+        self.is_modified = False
+
+    def check_modified(self, current_content):
+        normalized_current = self.normalize(current_content)
+        self.is_modified = (normalized_current != self.last_saved_content)
+        return self.is_modified
+
+
+editor_state = EditorState()
+
 new_name = ""
-last_saved_content = None
 context_menu = None
-is_modified = False
 markdown_render_enabled = False
 add_current_main_opened_script_var = False
 include_selected_text_in_command = False
@@ -54,7 +77,6 @@ original_md_content = None
 render_markdown_var = None
 rendered_html_content = None
 current_session = None
-file_name = ""
 current_font_family = "Liberation Mono"
 current_font_size = 12
 fontColor = "#000000"


### PR DESCRIPTION
This PR addresses the issue where files were marked as modified immediately upon opening, even without any user edits. It also ensures that the modification indicator (asterisk) correctly reflects whether the current content differs from the original file, ignoring trivial trailing newline discrepancies. 

Key changes include:
1. **Centralized State Management:** Replaced multiple, potentially inconsistent global variables with a single `EditorState` instance in `tk_utils.py`.
2. **Robust Change Detection:** Migrated from `<Key>` event bindings to the `<<Modified>>` virtual event and added a normalization step (`rstrip('\n')`) during comparison.
3. **Automatic State Reversal:** If a user undoes changes or manually edits the text back to its original state, the modified flag is now correctly cleared.
4. **Improved Reliability:** Updated file operations to properly reset the internal modified flag of the text widget after loading or saving.
5. **Brittle Code Fixes:** Refactored execution logic to use the centralized `file_name` instead of parsing UI labels.

---
*PR created automatically by Jules for task [2876956516520861945](https://jules.google.com/task/2876956516520861945) started by @Axlfc*