### PR TITLE
Fix CTkTextbox AttributeError in AI Assistant and Editor

### DIFF
--- a/src/controllers/file_operations.py
+++ b/src/controllers/file_operations.py
@@ -90,8 +90,8 @@ def open_file(file_path):
 
     script_text.delete("1.0", END)
     script_text.insert("1.0", script_content)
-    script_text.mark_set("insert", "1.0")
-    script_text.see("1.0")
+    script_text._textbox.mark_set("insert", "1.0")
+    script_text._textbox.see("1.0")
 
     print("SAVING FILE CONTENT HERE TO LAST_SAVED_CONTENT")
     editor_state.update_original_content(script_content)

--- a/src/controllers/tool_functions.py
+++ b/src/controllers/tool_functions.py
@@ -999,9 +999,9 @@ def open_ai_assistant_window(session_id=None):
     status_label = customtkinter.CTkLabel(ai_assistant_window, textvariable=status_label_var)
     status_label.pack(side="bottom", pady=(0, 5))
     status_label_var.set("READY")
-    output_text.tag_configure("user", foreground="#a84699")
-    output_text.tag_configure("ai", foreground="#6a7fd2")
-    output_text.tag_configure("error", foreground="red")
+    output_text._textbox.tag_configure("user", foreground="#a84699")
+    output_text._textbox.tag_configure("ai", foreground="#6a7fd2")
+    output_text._textbox.tag_configure("error", foreground="red")
     output_text.insert(END, "> ", "ai")
     entry.focus()
 
@@ -1393,8 +1393,8 @@ def open_ai_assistant_window(session_id=None):
                 return (
                         "```\n"
                         + script_text.get(
-                    script_text.tag_ranges("sel")[0],
-                    script_text.tag_ranges("sel")[1])
+                    script_text._textbox.tag_ranges("sel")[0],
+                    script_text._textbox.tag_ranges("sel")[1])
                         + "```\n\n"
                 )
             except:
@@ -1609,7 +1609,7 @@ def open_ai_assistant_window(session_id=None):
 
     output_text.bind("<Button-3>", show_context_menu)
     output_text.bind("<<TextModified>>", on_md_content_change)
-    output_text.see(END)
+    output_text._textbox.see(END)
     '''entry.bind(
         "<Return>",
         lambda event: execute_ai_assistant_command(
@@ -1960,7 +1960,7 @@ def open_ai_assistant_window(session_id=None):
                 output_text.insert(
                     END, f"{message['role']}: {message['content']}\n", role_tag
                 )
-        output_text.see(END)
+        output_text._textbox.see(END)
 
     def load_session(session_id):
         global current_session

--- a/src/controllers/utility_functions.py
+++ b/src/controllers/utility_functions.py
@@ -19,11 +19,11 @@ def bold(event=None):
     None
     ""\"
     ""\" """
-    current_tags = text.tag_names()
+    current_tags = text._textbox.tag_names()
     if "bold" in current_tags:
-        text.tag_delete("bold", 1.0, END)
+        text._textbox.tag_delete("bold", 1.0, END)
     else:
-        text.tag_add("bold", 1.0, END)
+        text._textbox.tag_add("bold", 1.0, END)
     make_tag()
 
 
@@ -42,12 +42,12 @@ def italic(event=None):
     None
     ""\"
     ""\" """
-    current_tags = text.tag_names()
+    current_tags = text._textbox.tag_names()
     if "italic" in current_tags:
-        text.tag_add("roman", 1.0, END)
-        text.tag_delete("italic", 1.0, END)
+        text._textbox.tag_add("roman", 1.0, END)
+        text._textbox.tag_delete("italic", 1.0, END)
     else:
-        text.tag_add("italic", 1.0, END)
+        text._textbox.tag_add("italic", 1.0, END)
     make_tag()
 
 
@@ -66,11 +66,11 @@ def underline(event=None):
     None
     ""\"
     ""\" """
-    current_tags = text.tag_names()
+    current_tags = text._textbox.tag_names()
     if "underline" in current_tags:
-        text.tag_delete("underline", 1.0, END)
+        text._textbox.tag_delete("underline", 1.0, END)
     else:
-        text.tag_add("underline", 1.0, END)
+        text._textbox.tag_add("underline", 1.0, END)
     make_tag()
 
 
@@ -90,11 +90,11 @@ def strike():
     None
     ""\"
     ""\" """
-    current_tags = text.tag_names()
+    current_tags = text._textbox.tag_names()
     if "overstrike" in current_tags:
-        text.tag_delete("overstrike", "1.0", END)
+        text._textbox.tag_delete("overstrike", "1.0", END)
     else:
-        text.tag_add("overstrike", 1.0, END)
+        text._textbox.tag_add("overstrike", 1.0, END)
     make_tag()
 
 
@@ -117,11 +117,11 @@ def highlight():
     color_rgb = color[1]
     global fontBackground
     fontBackground = color_rgb
-    current_tags = text.tag_names()
+    current_tags = text._textbox.tag_names()
     if "background_color_change" in current_tags:
-        text.tag_delete("background_color_change", "1.0", END)
+        text._textbox.tag_delete("background_color_change", "1.0", END)
     else:
-        text.tag_add("background_color_change", "1.0", END)
+        text._textbox.tag_add("background_color_change", "1.0", END)
     make_tag()
 
 
@@ -141,8 +141,8 @@ def align_center(event=None):
     ""\"
     ""\" """
     remove_align_tags()
-    text.tag_configure("center", justify="center")
-    text.tag_add("center", 1.0, "end")
+    text._textbox.tag_configure("center", justify="center")
+    text._textbox.tag_add("center", 1.0, "end")
 
 
 def align_justify():
@@ -173,8 +173,8 @@ def align_left(event=None):
     ""\"
     ""\" """
     remove_align_tags()
-    text.tag_configure("left", justify="left")
-    text.tag_add("left", 1.0, "end")
+    text._textbox.tag_configure("left", justify="left")
+    text._textbox.tag_add("left", 1.0, "end")
 
 
 def align_right(event=None):
@@ -190,8 +190,8 @@ def align_right(event=None):
     ""\"
     ""\" """
     remove_align_tags()
-    text.tag_configure("right", justify="right")
-    text.tag_add("right", 1.0, "end")
+    text._textbox.tag_configure("right", justify="right")
+    text._textbox.tag_add("right", 1.0, "end")
 
 
 def change_font(event):
@@ -251,7 +251,7 @@ def make_tag():
     None
     ""\"
     ""\" """
-    current_tags = text.tag_names()
+    current_tags = text._textbox.tag_names()
     if "bold" in current_tags:
         weight = "bold"
     else:
@@ -277,12 +277,12 @@ def make_tag():
         overstrike=overstrike,
         family=current_font_family,
         size=current_font_size)
-    text.tag_config(
+    text._textbox.tag_config(
         "BigTag", font=big_font, foreground=fontColor, background=fontBackground
     )
     if "BigTag" in current_tags:
-        text.tag_remove("BigTag", 1.0, END)
-    text.tag_add("BigTag", 1.0, END)
+        text._textbox.tag_remove("BigTag", 1.0, END)
+    text._textbox.tag_add("BigTag", 1.0, END)
 
 
 def remove_align_tags():
@@ -300,13 +300,13 @@ def remove_align_tags():
     None
     ""\"
     ""\" """
-    all_tags = text.tag_names(index=None)
+    all_tags = text._textbox.tag_names(index=None)
     if "center" in all_tags:
-        text.tag_remove("center", "1.0", END)
+        text._textbox.tag_remove("center", "1.0", END)
     if "left" in all_tags:
-        text.tag_remove("left", "1.0", END)
+        text._textbox.tag_remove("left", "1.0", END)
     if "right" in all_tags:
-        text.tag_remove("right", "1.0", END)
+        text._textbox.tag_remove("right", "1.0", END)
 
 
 def validate_time(hour, minute):

--- a/src/views/app_layers.py
+++ b/src/views/app_layers.py
@@ -69,7 +69,7 @@ def on_tab_change(tab):
             target.configure(autoseparators=True)
         else:
             tab.textbox.insert("1.0", tab.content)
-            tab.textbox.mark_set("insert", "1.0")
+            tab.textbox._textbox.mark_set("insert", "1.0")
             tab.textbox._textbox.edit_reset()
 
         tab.textbox._textbox.edit_modified(False)
@@ -344,7 +344,7 @@ def ensure_scroll_sync():
     try:
         if line_numbers and line_numbers.winfo_exists() and script_text._widget.winfo_exists():
             # Get current text widget view
-            first, last = script_text.yview()
+            first, last = script_text._textbox.yview()
             # Update line numbers
             line_numbers.redraw()
     except Exception:

--- a/src/views/edit_operations.py
+++ b/src/views/edit_operations.py
@@ -80,7 +80,7 @@ def select_all():
     Returns:
         None: Description of return value.
     ""\" """
-    text.tag_add("start", "1.0", "end")
+    text._textbox.tag_add("start", "1.0", "end")
 
 
 def cut():

--- a/src/window/SearchAndReplaceWindow.py
+++ b/src/window/SearchAndReplaceWindow.py
@@ -51,7 +51,7 @@ class SearchAndReplaceWindow:
         if search_text:
             start_index = "1.0"
             while True:
-                start_index = self.script_text.search(search_text, start_index, nocase=1, stopindex=END)
+                start_index = self.script_text._textbox.search(search_text, start_index, nocase=1, stopindex=END)
                 if not start_index:
                     break
                 end_index = f"{start_index}+{len(search_text)}c"

--- a/src/window/SearchWindow.py
+++ b/src/window/SearchWindow.py
@@ -43,19 +43,19 @@ class SearchWindow:
 
     def find_text(self):
         value = self.search_entry_widget.get()
-        self.script_text.tag_remove("found", "1.0", END)
+        self.script_text._textbox.tag_remove("found", "1.0", END)
         if value:
-            self.script_text.tag_config("found", background="yellow")
+            self.script_text._textbox.tag_config("found", background="yellow")
             idx = "1.0"
             while idx:
-                idx = self.script_text.search(value, idx, nocase=1, stopindex=END)
+                idx = self.script_text._textbox.search(value, idx, nocase=1, stopindex=END)
                 if idx:
                     lastidx = f"{idx}+{len(value)}c"
-                    self.script_text.tag_add("found", idx, lastidx)
+                    self.script_text._textbox.tag_add("found", idx, lastidx)
                     idx = lastidx
 
     def cancel(self):
-        self.script_text.tag_remove("found", "1.0", END)
+        self.script_text._textbox.tag_remove("found", "1.0", END)
         self.search_toplevel.destroy()
 
 


### PR DESCRIPTION
I have fixed the `AttributeError: 'CTkTextbox' object has no attribute 'tag_configure'` and similar errors occurring in the AI Assistant window and other parts of the IDE. 

Key changes:
- Accessed the internal `._textbox` widget of `customtkinter.CTkTextbox` for methods not exposed by the wrapper: `tag_configure`, `tag_add`, `tag_remove`, `tag_names`, `tag_config`, `tag_ranges`, `mark_set`, `see`, `yview`, and `search`.
- Updated `src/controllers/tool_functions.py` to fix the AI Assistant output coloring and scrolling.
- Updated `src/views/app_layers.py`, `src/controllers/file_operations.py`, `src/views/edit_operations.py`, and `src/controllers/utility_functions.py` to ensure the main editor operations (tags, marks, scrolling) work correctly with `CTkTextbox`.
- Updated `src/window/SearchWindow.py` and `src/window/SearchAndReplaceWindow.py` to fix search and highlighting functionality.
- Verified that methods like `insert()`, `delete()`, `get()`, and `configure()` continue to be called directly as they are supported by the wrapper.
- Confirmed that windows using standard `tkinter.Text` or `scrolledtext.ScrolledText` widgets were not affected by these changes.

---
*PR created automatically by Jules for task [14841750992371301](https://jules.google.com/task/14841750992371301) started by @Axlfc*