### PR TITLE
Fix Import SyntaxErrors and Reorganize Imports

### DIFF
--- a/src/window/FindInFilesWindow.py
+++ b/src/window/FindInFilesWindow.py
@@ -1,14 +1,22 @@
-﻿import os
+# Imports estándar
+import os
 import re
 import threading
 import fnmatch
+
+# Imports de tkinter
 import tkinter as tk
-import customtkinter as ctk
-from src.utils.thread_manager import thread_manager
-from tkinter import (
-    BooleanVar, tk.END, filedialog, StringVar
-)
+from tkinter import filedialog, BooleanVar, StringVar
 from tkinter.ttk import Treeview
+
+# Imports de customtkinter
+from customtkinter import (
+    CTkButton, CTkEntry, CTkLabel, CTkFrame,
+    CTkCheckBox, CTkScrollbar
+)
+
+# Imports locales
+from src.utils.thread_manager import thread_manager
 from src.ui.themed_window import ThemedWindow
 
 
@@ -34,7 +42,7 @@ class FindInFilesWindow(ThemedWindow):
         self.grid_columnconfigure(0, weight=1)
         self.grid_rowconfigure(0, weight=1)
 
-        self.main_container = ctk.CTkFrame(self)
+        self.main_container = CTkFrame(self)
         self.main_container.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 
         # Setup UI components
@@ -42,50 +50,50 @@ class FindInFilesWindow(ThemedWindow):
 
     def setup_ui(self):
         # Input frame
-        input_frame = ctk.CTkFrame(self.main_container, fg_color="transparent")
+        input_frame = CTkFrame(self.main_container, fg_color="transparent")
         input_frame.pack(fill=tk.X, padx=10, pady=10)
 
         # Search input
-        ctk.CTkLabel(input_frame, text="Search:").grid(row=0, column=0, sticky="e", padx=5, pady=5)
-        self.search_entry = ctk.CTkEntry(input_frame, width=300)
+        CTkLabel(input_frame, text="Search:").grid(row=0, column=0, sticky="e", padx=5, pady=5)
+        self.search_entry = CTkEntry(input_frame, width=300)
         self.search_entry.grid(row=0, column=1, sticky="ew", padx=5, pady=5)
 
         # Case sensitivity option
         self.case_sensitive_var = tk.BooleanVar()
-        ctk.CTkCheckBox(input_frame, text="Case Sensitive", variable=self.case_sensitive_var).grid(row=0, column=2,
+        CTkCheckBox(input_frame, text="Case Sensitive", variable=self.case_sensitive_var).grid(row=0, column=2,
                                                                                                     padx=5)
 
         # Path input
-        ctk.CTkLabel(input_frame, text="Path:").grid(row=1, column=0, sticky="e", padx=5, pady=5)
-        self.path_entry = ctk.CTkEntry(input_frame, width=300)
+        CTkLabel(input_frame, text="Path:").grid(row=1, column=0, sticky="e", padx=5, pady=5)
+        self.path_entry = CTkEntry(input_frame, width=300)
         self.path_entry.grid(row=1, column=1, sticky="ew", padx=5, pady=5)
         self.path_entry.insert(0, os.getcwd())
 
         # Browse button
-        ctk.CTkButton(input_frame, text="Browse", width=80, command=self.browse_directory).grid(row=1, column=2, padx=5, pady=5)
+        CTkButton(input_frame, text="Browse", width=80, command=self.browse_directory).grid(row=1, column=2, padx=5, pady=5)
 
         # Filter input
-        ctk.CTkLabel(input_frame, text="Filter:").grid(row=2, column=0, sticky="e", padx=5, pady=5)
-        self.filter_entry = ctk.CTkEntry(input_frame, width=300)
+        CTkLabel(input_frame, text="Filter:").grid(row=2, column=0, sticky="e", padx=5, pady=5)
+        self.filter_entry = CTkEntry(input_frame, width=300)
         self.filter_entry.grid(row=2, column=1, sticky="ew", padx=5, pady=5)
         self.filter_entry.insert(0, "*.py")
 
         # Include subdirectories option
         self.include_subdirs_var = tk.BooleanVar(value=True)
-        ctk.CTkCheckBox(input_frame, text="Include Subdirectories", variable=self.include_subdirs_var).grid(row=2,
+        CTkCheckBox(input_frame, text="Include Subdirectories", variable=self.include_subdirs_var).grid(row=2,
                                                                                                              column=2,
                                                                                                              padx=5)
 
         # Button frame
-        button_frame = ctk.CTkFrame(self.main_container, fg_color="transparent")
+        button_frame = CTkFrame(self.main_container, fg_color="transparent")
         button_frame.pack(fill=tk.X, padx=10, pady=5)
 
         # Find and Cancel buttons
-        ctk.CTkButton(button_frame, text="Find", width=100, command=self.start_search).pack(side=tk.RIGHT, padx=5)
-        ctk.CTkButton(button_frame, text="Cancel", width=100, command=self.destroy).pack(side=tk.RIGHT, padx=5)
+        CTkButton(button_frame, text="Find", width=100, command=self.start_search).pack(side=tk.RIGHT, padx=5)
+        CTkButton(button_frame, text="Cancel", width=100, command=self.destroy).pack(side=tk.RIGHT, padx=5)
 
         # Results frame with Treeview
-        self.results_frame = ctk.CTkFrame(self.main_container)
+        self.results_frame = CTkFrame(self.main_container)
         self.results_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 
         # Set up Treeview for results display
@@ -93,7 +101,7 @@ class FindInFilesWindow(ThemedWindow):
 
         # Progress label
         self.progress_var = tk.StringVar(value="Ready")
-        self.progress_label = ctk.CTkLabel(self.main_container, textvariable=self.progress_var)
+        self.progress_label = CTkLabel(self.main_container, textvariable=self.progress_var)
         self.progress_label.pack(fill=tk.X, pady=5)
 
     def setup_results_tree(self):
@@ -110,8 +118,8 @@ class FindInFilesWindow(ThemedWindow):
         self.results_tree.column("Text", width=400)
 
         # Add scrollbars
-        vsb = ctk.CTkScrollbar(self.results_frame, orientation="vertical", command=self.results_tree.yview)
-        hsb = ctk.CTkScrollbar(self.results_frame, orientation="horizontal", command=self.results_tree.xview)
+        vsb = CTkScrollbar(self.results_frame, orientation="vertical", command=self.results_tree.yview)
+        hsb = CTkScrollbar(self.results_frame, orientation="horizontal", command=self.results_tree.xview)
         self.results_tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
 
         # Grid scrollbars and treeview
@@ -233,5 +241,3 @@ class FindInFilesWindow(ThemedWindow):
             file_path, line_num, _ = values
             full_path = os.path.join(self.path_entry.get(), file_path)
             print(f"Opening {full_path} at line {line_num}")
-
-

--- a/src/window/SettingsWindow.py
+++ b/src/window/SettingsWindow.py
@@ -1,24 +1,24 @@
-import tkinter as tk
-﻿import json
+# Imports estándar
 import os
-from tkinter import (
-    StringVar,
-    messagebox,
-    font,
-    tk.BOTH,
-    tk.LEFT,
-    tk.X,
-    BooleanVar,
-    BOTTOM
-)
-from tkinter.ttk import Notebook
+import json
 
-from src.controllers.parameters import (read_config_parameter, write_config_parameter,
-                                        get_appearance_mode)
+# Imports de tkinter
+import tkinter as tk
+from tkinter import StringVar, messagebox, font, BooleanVar
+from tkinter import BOTTOM
+
+# Imports de customtkinter
+from customtkinter import (
+    CTkFrame, CTkTabview, CTkScrollableFrame, CTkLabel,
+    CTkComboBox, CTkCheckBox, CTkEntry, CTkButton
+)
+
+# Imports locales
+from src.controllers.parameters import (
+    read_config_parameter, write_config_parameter, get_appearance_mode
+)
 from src.models.LanguageManager import LanguageManager
-import customtkinter as ctk
-from src.views.tk_utils import style
-from src.views.ui_elements import ScrollableFrame
+from src.views.tk_utils import style, unregister_window_for_theme
 from src.ui.themed_window import ThemedWindow
 
 
@@ -97,17 +97,17 @@ class SettingsWindow(ThemedWindow):
     def setup_ui(self):
         """Setup the main UI components."""
         # Main frame
-        self.main_frame = customtkinter.CTkFrame(self)
+        self.main_frame = CTkFrame(self)
         self.main_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 
         # Notebook for tabs
         # Note: CTk doesn't have a Notebook, so we use a Frame with segmented buttons or just keep ttk Notebook
         # To keep it simple and consistent with other IDEs, let's use a Tabview
-        self.tabview = customtkinter.CTkTabview(self.main_frame)
+        self.tabview = CTkTabview(self.main_frame)
         self.tabview.pack(fill=tk.BOTH, expand=True)
 
         # Bottom frame for buttons
-        self.bottom_frame = customtkinter.CTkFrame(self)
+        self.bottom_frame = CTkFrame(self)
         self.bottom_frame.pack(fill=tk.X, side=BOTTOM, padx=10, pady=10)
 
         self.create_settings_sections()
@@ -121,7 +121,7 @@ class SettingsWindow(ThemedWindow):
             tab_frame = self.tabview.tab(tab_name)
 
             # Use CTkScrollableFrame
-            scrollable_frame = customtkinter.CTkScrollableFrame(tab_frame)
+            scrollable_frame = CTkScrollableFrame(tab_frame)
             scrollable_frame.pack(fill=tk.BOTH, expand=True)
 
             self.create_option_widgets(scrollable_frame, section, options)
@@ -129,7 +129,7 @@ class SettingsWindow(ThemedWindow):
     def create_option_widgets(self, scrollable_frame, section, options):
         """Create widgets for each option in a section."""
         for row, (option_name, default_value) in enumerate(options.items()):
-            label = customtkinter.CTkLabel(
+            label = CTkLabel(
                 scrollable_frame,
                 text=option_name.replace("_", " ").capitalize()
             )
@@ -165,7 +165,7 @@ class SettingsWindow(ThemedWindow):
             )
 
             var = tk.StringVar(value=current_lang_name)
-            widget = customtkinter.CTkComboBox(parent, variable=var, values=language_display_list)
+            widget = CTkComboBox(parent, variable=var, values=language_display_list)
 
             # Store the reverse mapping for saving
             self._orig_language_var = var
@@ -182,46 +182,40 @@ class SettingsWindow(ThemedWindow):
             font_families = list(font.families())
             default_font = default_value if default_value in font_families else "Courier New"
             var = tk.StringVar(value=default_font)
-            widget = customtkinter.CTkComboBox(parent, variable=var, values=font_families)
+            widget = CTkComboBox(parent, variable=var, values=font_families)
             return widget, var
 
         elif option_name.lower() == "theme":
             themes = self.load_themes_from_json("data/themes.json")
             default_theme = default_value if default_value in themes else themes[0]
             var = tk.StringVar(value=default_theme)
-            widget = customtkinter.CTkComboBox(parent, variable=var, values=themes)
+            widget = CTkComboBox(parent, variable=var, values=themes)
             return widget, var
 
         elif option_name.lower() == "mode":
             modes = ["System", "Light", "Dark"]
             var = tk.StringVar(value=default_value)
-            widget = customtkinter.CTkComboBox(parent, variable=var, values=modes)
-            return widget, var
-
-        elif option_name.lower() == "mode":
-            modes = ["System", "Light", "Dark"]
-            var = tk.StringVar(value=default_value)
-            widget = Combobox(parent, textvariable=var, values=modes)
+            widget = CTkComboBox(parent, variable=var, values=modes)
             return widget, var
 
         elif isinstance(default_value, bool):
             var = tk.BooleanVar(value=default_value)
-            widget = customtkinter.CTkCheckBox(parent, text="", variable=var)
+            widget = CTkCheckBox(parent, text="", variable=var)
             return widget, var
 
         elif isinstance(default_value, (str, int)):
             var = tk.StringVar(value=str(default_value))
-            widget = customtkinter.CTkEntry(parent, textvariable=var)
+            widget = CTkEntry(parent, textvariable=var)
             return widget, var
 
         return None, None
 
     def create_buttons(self):
         """Create save and reset buttons."""
-        save_button = customtkinter.CTkButton(self.bottom_frame, text="Save Settings", command=self.save_settings)
+        save_button = CTkButton(self.bottom_frame, text="Save Settings", command=self.save_settings)
         save_button.pack(side=tk.LEFT, padx=5)
 
-        reset_button = customtkinter.CTkButton(self.bottom_frame, text="Reset Settings", command=self.reset_settings)
+        reset_button = CTkButton(self.bottom_frame, text="Reset Settings", command=self.reset_settings)
         reset_button.pack(side=tk.LEFT, padx=5)
 
     def save_settings(self):

--- a/src/window/TranslatorWindow.py
+++ b/src/window/TranslatorWindow.py
@@ -1,15 +1,20 @@
-import tkinter as tk
-﻿from tkinter import *
-from tkinter import scrolledtext
-from tkinter.ttk import Combobox
-from datetime import datetime
+# Imports estándar
+import os
 import subprocess
 import platform
-import os
 import time
+from datetime import datetime
 
-from src.views.tk_utils import my_font
+# Imports de tkinter
+import tkinter as tk
+from tkinter import scrolledtext
+from tkinter.ttk import Combobox
+
+# Imports de customtkinter
 import customtkinter as ctk
+
+# Imports locales
+from src.views.tk_utils import my_font
 from src.ui.themed_window import ThemedWindow
 
 
@@ -165,6 +170,3 @@ class TranslatorWindow(ThemedWindow):
             return [python_executable, ai_script_path, user_prompt, agent_name]
         else:
             return [python_executable, ai_script_path, user_prompt]
-
-
-


### PR DESCRIPTION
This submission fixes a critical SyntaxError in the imports of FindInFilesWindow.py and other files. It also reorganizes and cleans up the import sections across several window classes to follow the project's recommended format and facilitate the migration to customtkinter.

Key changes:
1. **FindInFilesWindow.py**: Resolved SyntaxError by removing `tk.END` from the `from tkinter import` block. Reorganized imports and switched to direct widget imports from `customtkinter`.
2. **SettingsWindow.py**: Removed a misplaced BOM at line 2 and fixed a SyntaxError in the tkinter import block. Cleaned up redundant code and ensured all necessary local imports are present.
3. **TranslatorWindow.py**: Removed a misplaced BOM at line 2 and replaced the wildcard import `from tkinter import *` with explicit imports.
4. **Project-wide**: Verified the absence of SyntaxErrors in the `src/` directory using `python3 -m compileall src/`.

---
*PR created automatically by Jules for task [14866738336276779227](https://jules.google.com/task/14866738336276779227) started by @Axlfc*