### PR TITLE
Add Ollama model selection dropdown

### DIFF
--- a/data/locales/ca.json
+++ b/data/locales/ca.json
@@ -177,5 +177,11 @@
     "about_scripts_editor_about": "Quant a Editor de Scripts",
     "application_title": "Editor de Scripts",
     "application_info": "Editor de Scripts és un editor de text versàtil i potent dissenyat per millorar la teva productivitat.\nAmb multitud de funcions i opcions de personalització, satisfà tant a principiants com a professionals.\n\nVersió: 1.0.0\nAutor: Axel Fernández Curros\nLlicència: Llicència GPL-2.0",
-    "close": "Tancar"
+    "close": "Tancar",
+
+    "ai_server_settings_title": "Configuració del Servidor d'IA",
+    "ai_server_select_server_label": "Seleccionar Servidor:",
+    "ai_server_url_label": "URL del Servidor:",
+    "ai_server_api_key_label": "Clau d'API del Servidor:",
+    "ai_server_model_label": "Model:"
 }

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -204,7 +204,8 @@
     "ai_server_settings_title": "AI Server Settings",
     "ai_server_select_server_label": "Select Server:",
     "ai_server_url_label": "Server URL:",
-    "ai_server_api_key_label": "Server URL:",
+    "ai_server_api_key_label": "API Key:",
+    "ai_server_model_label": "Model:",
 
     "ai_server_agent_settings_title": "AI Server Agent Settings",
     "ai_server_select_agent_label": "Select Agent:",

--- a/data/locales/es.json
+++ b/data/locales/es.json
@@ -202,6 +202,7 @@
     "ai_server_select_server_label": "Seleccionar Servidor:",
     "ai_server_url_label": "URL del Servidor:",
     "ai_server_api_key_label": "Clave de API del Servidor:",
+    "ai_server_model_label": "Modelo:",
 
     "ai_server_agent_settings_title": "Configuración del Agente del Servidor de IA",
     "ai_server_select_agent_label": "Seleccionar Agente:",

--- a/src/controllers/tool_functions.py
+++ b/src/controllers/tool_functions.py
@@ -67,6 +67,38 @@ def open_llama_cpp_python_settings_window():
 def open_ai_server_settings_window():
     json_path = "data/llm_server_providers.json"
 
+    def fetch_ollama_models():
+        url = server_url_entry.get()
+        if not url:
+            return
+
+        base_url = url
+        if "/api/generate" in base_url:
+            base_url = base_url.replace("/api/generate", "")
+        if not base_url.startswith("http"):
+            base_url = "http://" + base_url
+
+        try:
+            base_url = base_url.rstrip("/")
+            response = requests.get(f"{base_url}/api/tags", timeout=5)
+            if response.status_code == 200:
+                data = response.json()
+                models = [m["name"] for m in data.get("models", [])]
+                if models:
+                    ollama_model_dropdown.configure(values=models)
+                    current_model = selected_ollama_model.get()
+                    if current_model not in models:
+                        selected_ollama_model.set(models[0])
+                else:
+                    ollama_model_dropdown.configure(values=["No models found"])
+            else:
+                ollama_model_dropdown.configure(values=[f"Error: {response.status_code}"])
+        except Exception:
+            ollama_model_dropdown.configure(values=["Server unreachable"])
+
+    def fetch_ollama_models_async():
+        threading.Thread(target=fetch_ollama_models, daemon=True).start()
+
     def toggle_display(selected_server):
         server_info = server_details.get(selected_server, {})
         server_url = server_info.get("server_url", "")
@@ -101,6 +133,14 @@ def open_ai_server_settings_window():
         else:
             euriai_model_label.grid_remove()
             euriai_model_dropdown.grid_remove()
+
+        if selected_server == "ollama":
+            ollama_model_label.grid(row=3, column=0, sticky="w", padx=10, pady=10)
+            ollama_model_frame.grid(row=3, column=1, sticky="ew", padx=10, pady=10)
+            fetch_ollama_models_async()
+        else:
+            ollama_model_label.grid_remove()
+            ollama_model_frame.grid_remove()
 
     def load_server_details():
         try:
@@ -179,6 +219,9 @@ def open_ai_server_settings_window():
                 "No changes made. The API Key entered is a placeholder.")
         if selected == "euriai":
             write_config_parameter("options.network_settings.euriai_model", selected_euriai_model.get())
+        if selected == "ollama":
+            write_config_parameter("options.network_settings.ollama_model", selected_ollama_model.get())
+            write_config_parameter("options.network_settings.ollama_url", server_url)
         write_config_parameter(
             "options.network_settings.last_selected_llm_server_provider", selected
         )
@@ -223,8 +266,18 @@ def open_ai_server_settings_window():
     selected_euriai_model.set(read_config_parameter("options.network_settings.euriai_model") or euriai_models[0])
     euriai_model_dropdown = customtkinter.CTkComboBox(settings_window, variable=selected_euriai_model, values=euriai_models)
 
+    ollama_model_label = customtkinter.CTkLabel(settings_window, text=localization_data.get("ai_server_model_label", "Model:"))
+    selected_ollama_model = StringVar(settings_window)
+    selected_ollama_model.set(read_config_parameter("options.network_settings.ollama_model") or "")
+
+    ollama_model_frame = customtkinter.CTkFrame(settings_window, fg_color="transparent")
+    ollama_model_dropdown = customtkinter.CTkComboBox(ollama_model_frame, variable=selected_ollama_model, values=[])
+    ollama_model_dropdown.pack(side="left", fill="x", expand=True, padx=(0, 5))
+    ollama_refresh_button = customtkinter.CTkButton(ollama_model_frame, text="↻", width=30, command=fetch_ollama_models_async)
+    ollama_refresh_button.pack(side="left")
+
     customtkinter.CTkButton(settings_window, text=localization_data["save"], command=save_ai_server_settings).grid(
-        row=4, column=0, columnspan=2, pady=20
+        row=5, column=0, columnspan=2, pady=20
     )
     selected_server.trace("w", lambda *args: toggle_display(selected_server.get()))
     toggle_display(selected_server.get())

--- a/src/models/ai_assistant.py
+++ b/src/models/ai_assistant.py
@@ -393,7 +393,15 @@ def chat_loop_ollama(prompt, system_prompt, session_id):
     }
 
     try:
-        response = requests.post(f"{ollama_url}/api/generate", headers=headers, json=data)
+        if "/api/generate" in ollama_url:
+            full_url = ollama_url
+        else:
+            full_url = f"{ollama_url.rstrip('/')}/api/generate"
+
+        if not full_url.startswith("http"):
+            full_url = "http://" + full_url
+
+        response = requests.post(full_url, headers=headers, json=data)
         response.raise_for_status()
         # TODO: Only getting the content under 'response' but if it invents another it may not be properly parsing
         raw_response = response.json().get("response", "")


### PR DESCRIPTION
This change introduces a more user-friendly way to select Ollama models in the AI Server Settings. 

Key changes:
1.  **Ollama Model Dropdown**: When 'ollama' is selected as the AI provider, a new 'Model' field appears with a dropdown containing available models fetched directly from the local Ollama instance (via `/api/tags`).
2.  **Asynchronous Loading**: Models are loaded in a background thread to prevent UI freezing.
3.  **Manual Refresh**: Added a '↻' button next to the model dropdown to allow users to manually re-fetch models if the server was started after opening the settings.
4.  **Localization**: Added `ai_server_model_label` to English, Spanish, and Catalan locale files. Fixed a typo in `en.json` where `ai_server_api_key_label` was incorrectly labeled.
5.  **Robust URL Handling**: Updated `chat_loop_ollama` in `src/models/ai_assistant.py` to handle URLs more gracefully, ensuring that `/api/generate` is correctly appended regardless of how the user entered the server URL.
6.  **Config Persistence**: The selected model and the synced Ollama URL are correctly saved to the user configuration.

---
*PR created automatically by Jules for task [4427584550716114433](https://jules.google.com/task/4427584550716114433) started by @Axlfc*