### PR TITLE
Fix LLM response parser to support Ollama JSON formats

### DIFF
--- a/src/core/nia_claude_client.py
+++ b/src/core/nia_claude_client.py
@@ -5,6 +5,7 @@ import os
 from typing import List, Dict, Optional
 from src.models.ai_assistant import AIAssistant
 from .plan_parser import Task
+from .robust_parser import RobustJSONParser
 from src.utils.path_utils import clean_filename, extract_filepath_from_text
 from src.prompts.templates import get_nia_iteration_prompt
 
@@ -16,11 +17,105 @@ class nIAResponse:
         self.test_file: Optional[str] = self._identify_test_file()
         self.test_name: Optional[str] = self._identify_test_name()
 
+    def _detect_response_format(self, text: str) -> str:
+        """Detect if response is Gemini markdown or Ollama JSON."""
+        # Try to extract JSON first
+        data = RobustJSONParser.extract_json(text)
+        if data:
+            if 'files' in data and isinstance(data['files'], list):
+                return 'ollama_json'
+            if 'tasks' in data and isinstance(data['tasks'], list):
+                return 'ollama_json_tasks'
+            # If it's some other JSON but we don't recognize the structure,
+            # we might still want to try parsing it if it has files
+            if any(k in data for k in ['files', 'tasks']):
+                return 'ollama_json'
+
+        # If no clear JSON structure, assume markdown
+        if 'File:' in text or '```' in text or '<file' in text:
+            return 'gemini_markdown'
+
+        return 'unknown'
+
+    def _parse_ollama_json(self, text: str) -> Dict[str, str]:
+        """Parse Ollama JSON format: {"files": [{"path": "...", "content": "..."}]}"""
+        files = {}
+        data = RobustJSONParser.extract_json(text)
+
+        if not data:
+            return files
+
+        if 'files' in data:
+            for file_obj in data['files']:
+                if isinstance(file_obj, dict):
+                    path = file_obj.get('path', '').strip() or file_obj.get('File', '').strip()
+                    content = file_obj.get('content', '')
+
+                    if path:
+                        path = os.path.normpath(path).replace('\\', '/')
+                        if path.startswith('./'): path = path[2:]
+                        files[path] = content
+                        logging.info(f"  ✅ Parsed (JSON): {path} ({len(content)} chars)")
+
+        return files
+
+    def _parse_ollama_json_tasks(self, text: str) -> Dict[str, str]:
+        """Parse Ollama format: {"tasks": [{"implementation": {"code_blocks": [...]}}]}"""
+        files = {}
+        data = RobustJSONParser.extract_json(text)
+
+        if not data:
+            return files
+
+        if 'tasks' in data:
+            for task in data['tasks']:
+                if not isinstance(task, dict): continue
+                impl = task.get('implementation', {})
+                if not isinstance(impl, dict): continue
+                code_blocks = impl.get('code_blocks', [])
+
+                if isinstance(code_blocks, list):
+                    for block in code_blocks:
+                        if not isinstance(block, dict): continue
+                        # Support both "File" and "path" keys
+                        file_path = block.get('File', '').strip() or block.get('path', '').strip()
+                        content = block.get('content', '')
+
+                        if file_path:
+                            file_path = os.path.normpath(file_path).replace('\\', '/')
+                            if file_path.startswith('./'): file_path = file_path[2:]
+                            files[file_path] = content
+                            logging.info(f"  ✅ Parsed (JSON Tasks): {file_path} ({len(content)} chars)")
+
+        return files
+
     def _parse_files(self, text: str) -> Dict[str, str]:
-        """Extract files from markdown code blocks with filenames."""
+        """Extract files from LLM response (Gemini OR Ollama format)."""
         files = {}
 
-        logging.info("--- Starting Robust File Parsing ---")
+        logging.info("--- Starting Universal File Parsing ---")
+
+        # Detect format
+        format_type = self._detect_response_format(text)
+        logging.info(f"📋 Detected format: {format_type}")
+
+        if format_type == 'ollama_json':
+            files = self._parse_ollama_json(text)
+        elif format_type == 'ollama_json_tasks':
+            files = self._parse_ollama_json_tasks(text)
+        else:
+            # Try both JSON parsers just in case detection failed but it is JSON
+            files = self._parse_ollama_json(text)
+            if not files:
+                files = self._parse_ollama_json_tasks(text)
+
+        # If we got files from JSON, we're done.
+        if files:
+            logging.info(f"📦 Total files extracted (JSON): {len(files)}")
+            return files
+
+        # Fallback to existing markdown parsing logic
+        logging.info("Falling back to Markdown parsing logic...")
 
         # 1. XML-style tags: <file path="path/to/file">content</file>
         xml_pattern = r'<file\s+path=["\']([^"\']+)["\']\s*>(.*?)</file>'

--- a/src/prompts/templates.py
+++ b/src/prompts/templates.py
@@ -168,7 +168,14 @@ File: js/app.js
 // ...
 ```
 
-Please complete this task now. Specify filenames as 'File: path/to/file'.
+Please complete this task now.
+Specify filenames as 'File: path/to/file' OR use a JSON response with a "files" array:
+{{
+  "files": [
+    {{"path": "path/to/file", "content": "..."}}
+  ]
+}}
+
 GENERATE COMPLETE, PRODUCTION-READY CODE NOW.
 """
 


### PR DESCRIPTION
This submission fixes a critical issue where the file parser was unable to detect and extract files from local LLM (Ollama) responses. The parser now supports both the traditional Gemini Markdown format and Ollama's JSON-based formats (both simple files array and task-based structure). The system prompt was also updated to explicitly allow and suggest the JSON format. Verified with unit tests and a reproduction script.

---
*PR created automatically by Jules for task [5201770305544330923](https://jules.google.com/task/5201770305544330923) started by @Axlfc*