### PR TITLE
Fix ModuleNotFoundError for 'resource' on Windows in SecureSandbox

### DIFF
--- a/src/security/sandbox.py
+++ b/src/security/sandbox.py
@@ -1,5 +1,8 @@
 import multiprocessing
-import resource
+try:
+    import resource
+except ImportError:
+    resource = None
 import os
 import sys
 import signal
@@ -52,6 +55,21 @@ class SecureSandbox:
         self.timeout = timeout
         self.memory_limit = memory_limit_mb * 1024 * 1024
 
+    def _apply_resource_limits(self):
+        """Apply resource limits if the platform supports it."""
+        if resource is None:
+            return
+
+        try:
+            resource.setrlimit(resource.RLIMIT_CPU, (self.timeout, self.timeout + 5))
+            resource.setrlimit(resource.RLIMIT_AS, (self.memory_limit, self.memory_limit))
+            resource.setrlimit(resource.RLIMIT_FSIZE, (10 * 1024 * 1024, 10 * 1024 * 1024))
+            resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+            resource.setrlimit(resource.RLIMIT_NPROC, (64, 64))
+        except Exception:
+            # Fallback for platforms where some limits might fail
+            pass
+
     def execute(self, code, allowed_imports=None, cwd=None, use_pytest=False):
         """
         Execute code in a separate process with resource limits.
@@ -101,14 +119,7 @@ class SecureSandbox:
         current_cwd = os.getcwd()
 
         # 2. Set Resource Limits
-        try:
-            resource.setrlimit(resource.RLIMIT_CPU, (self.timeout, self.timeout + 5))
-            resource.setrlimit(resource.RLIMIT_AS, (self.memory_limit, self.memory_limit))
-            resource.setrlimit(resource.RLIMIT_FSIZE, (10 * 1024 * 1024, 10 * 1024 * 1024))
-            resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
-            resource.setrlimit(resource.RLIMIT_NPROC, (64, 64))
-        except:
-            pass
+        self._apply_resource_limits()
 
         # 3. Capture Output
         stdout_capture = io.StringIO()

--- a/tests/test_windows_compatibility.py
+++ b/tests/test_windows_compatibility.py
@@ -1,0 +1,29 @@
+import sys
+from unittest.mock import patch
+import pytest
+
+def test_sandbox_without_resource():
+    # Force resource to be None in sys.modules to simulate Windows
+    with patch.dict(sys.modules, {'resource': None}):
+        # We need to reload the module to pick up the mocked None
+        import src.security.sandbox
+        from importlib import reload
+        reload(src.security.sandbox)
+
+        from src.security.sandbox import SecureSandbox
+
+        sandbox = SecureSandbox(timeout=5)
+        result = sandbox.execute("print('No resource, no problem')")
+
+        assert result['success']
+        assert "No resource, no problem" in result['stdout']
+
+    # Cleanup: reload sandbox again to restore original state for other tests
+    reload(src.security.sandbox)
+
+def test_sandbox_initialization_no_resource():
+    """Verify that SecureSandbox can be initialized even if resource is None."""
+    with patch('src.security.sandbox.resource', None):
+        from src.security.sandbox import SecureSandbox
+        sandbox = SecureSandbox()
+        assert sandbox is not None


### PR DESCRIPTION
The SecureSandbox class in RuneScript was causing a ModuleNotFoundError on Windows systems because it directly imported the 'resource' module, which is Unix-only. 

I refactored `src/security/sandbox.py` to:
1. Use a `try...except ImportError` block for the `resource` module.
2. Encapsulate resource-limiting logic in `_apply_resource_limits`.
3. Ensure the sandbox remains functional on Windows, even if strict OS-level resource limits from the `resource` module are not available.

I also added a new test file `tests/test_windows_compatibility.py` that mocks the absence of the `resource` module to ensure future portability.

---
*PR created automatically by Jules for task [16955523961478582979](https://jules.google.com/task/16955523961478582979) started by @Axlfc*