### PR TITLE
Automatic Selenium Dependency Recovery for Frontend Web Projects

### DIFF
--- a/src/core/loop_orchestrator.py
+++ b/src/core/loop_orchestrator.py
@@ -310,6 +310,22 @@ class LoopOrchestrator:
                         )
                         self._log_validation_result(val_red, "RED", log_callback)
 
+                        # AUTO-FIX for missing selenium in frontend_web
+                        if not val_red.success and "ModuleNotFoundError: No module named 'selenium'" in val_red.stderr and self.tech_stack == 'frontend_web':
+                            self._log("🔍 Detected missing 'selenium' dependency in RED phase. Auto-fixing...", log_callback)
+                            self._handle_missing_selenium(log_callback)
+
+                            # Retry RED phase
+                            self._log("🔄 Retrying RED phase after auto-fix...", log_callback)
+                            val_red = self.validator.validate_red(
+                                self.project_path,
+                                str(test_file_path),
+                                active_test_name,
+                                self.venv_python,
+                                output_callback=red_test_cb
+                            )
+                            self._log_validation_result(val_red, "RED (RETRY)", log_callback)
+
                         # Extract requirements from test for implementation phase
                         try:
                             reqs = TestParser.extract_requirements(test_content)
@@ -1105,6 +1121,50 @@ For example, if the test expects id="work", DO NOT use id="projects".
             missing.append(filename)
 
         return missing
+
+    def _handle_missing_selenium(self, log_callback=None):
+        """
+        Adds selenium to requirements.txt, updates sandbox whitelist, and installs the package.
+        """
+        self._log("📦 Auto-adding missing 'selenium' dependency...", log_callback)
+
+        try:
+            # 1. Add to requirements.txt
+            req_path = self.project_path / "requirements.txt"
+            content = ""
+            if req_path.exists():
+                try:
+                    content = req_path.read_text(encoding='utf-8')
+                except Exception:
+                    pass
+
+            if "selenium" not in content.lower():
+                new_content = content.rstrip() + "\nselenium\n"
+                req_path.write_text(new_content, encoding='utf-8')
+                self._log(f"✅ Added 'selenium' to {req_path.name}", log_callback)
+
+            # 2. Add to SecureSandbox whitelist via TDDValidator
+            if hasattr(self.validator, 'add_allowed_import'):
+                self.validator.add_allowed_import('selenium')
+                self._log("✅ Added 'selenium' to sandbox whitelist", log_callback)
+
+            # 3. Install package
+            python_exe = self.venv_python or sys.executable
+            self._log(f"Installing selenium using {python_exe}...", log_callback)
+
+            # Use --break-system-packages if we're using system python
+            cmd = [python_exe, "-m", "pip", "install", "selenium"]
+            if python_exe == sys.executable:
+                cmd.append("--break-system-packages")
+
+            result = subprocess.run(cmd, capture_output=True, encoding='utf-8', errors='replace')
+            if result.returncode == 0:
+                self._log("✅ selenium installed successfully.", log_callback)
+            else:
+                self._log(f"❌ Failed to install selenium: {result.stderr}", log_callback)
+
+        except Exception as e:
+            self._log(f"❌ Error during selenium auto-fix: {e}", log_callback)
 
     def _log_validation_result(self, result, phase_name: str, log_callback):
         """Log detailed validation result."""

--- a/src/core/tdd_validator.py
+++ b/src/core/tdd_validator.py
@@ -33,6 +33,12 @@ class TDDValidator:
         self.security_auditor = security_auditor
         self.sandbox = SecureSandbox()
         self.analyzer = CodeSecurityAnalyzer()
+        self.allowed_imports = ['pytest', 'bs4', 'beautifulsoup4', 're', 'json', 'math', 'unittest', 'os', 'pathlib']
+
+    def add_allowed_import(self, module_name: str):
+        """Dynamically add a module to the sandbox whitelist."""
+        if module_name not in self.allowed_imports:
+            self.allowed_imports.append(module_name)
 
     def validate_red(self, project_path: Path, test_file: str, test_name: str = None, venv_python: str = None, output_callback=None) -> ValidationResult:
         """
@@ -47,7 +53,8 @@ class TDDValidator:
             "command not found",
             "is not recognized as an internal or external command",
             "test file not found",
-            "python executable not found"
+            "python executable not found",
+            "ModuleNotFoundError: No module named 'selenium'"
         ]
 
         has_execution_error = any(err.lower() in result.stderr.lower() for err in execution_errors)
@@ -307,8 +314,8 @@ class TDDValidator:
                 # but let's try the sandbox first.
                 self.sandbox.timeout = 45 # Slightly more time for tests
 
-                # We need to decide which imports to allow based on the test
-                allowed = ['pytest', 'bs4', 'beautifulsoup4', 're', 'json', 'math', 'unittest', 'os', 'pathlib']
+                # Use dynamic whitelist from instance attribute
+                allowed = self.allowed_imports
 
                 # Check if we should use pytest
                 is_pytest = "import pytest" in code or "def test_" in code
@@ -517,7 +524,9 @@ class TDDValidator:
             # We can't easily run multiple files with our current sandbox.execute
             # so we'll run a script that calls pytest on the whole directory.
             code = "import pytest\nimport sys\nsys.exit(pytest.main(['.', '-v', '--ignore=.venv', '--ignore=venv', '--ignore=node_modules']))"
-            allowed = ['pytest', 'bs4', 'beautifulsoup4', 're', 'json', 'math', 'unittest', 'os', 'pathlib', 'sys']
+
+            # Ensure sys is available for this specific execution
+            allowed = list(set(self.allowed_imports + ['sys']))
 
             result = self.sandbox.execute(code, allowed_imports=allowed, cwd=str(project_path))
 
@@ -549,7 +558,7 @@ class TDDValidator:
                          threats_msg = ", ".join([t['description'] for t in analysis.get('threats', [])])
                          return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=f"Security Violation in test file {py_file.name}: {threats_msg}")
 
-                    allowed = ['pytest', 'bs4', 'beautifulsoup4', 're', 'json', 'math', 'unittest', 'os', 'pathlib']
+                    allowed = self.allowed_imports
                     is_pytest = "import pytest" in code or "def test_" in code
 
                     res = self.sandbox.execute(code, allowed_imports=allowed, cwd=str(project_path), use_pytest=is_pytest)


### PR DESCRIPTION
This change implements an automated recovery mechanism for projects using the `frontend_web` tech stack. When a test fails because the `selenium` module is missing (a common case for browser automation tests), the system now automatically handles the dependency by updating the project's configuration, whitelisting the module in the sandbox, and installing it. The test is then retried immediately, improving the autonomy and efficiency of the TDD loop.

---
*PR created automatically by Jules for task [11047341858558169232](https://jules.google.com/task/11047341858558169232) started by @Axlfc*