### PR TITLE
Fix JSON Parser Freeze on Backticks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ fake/
 lib/dia
 
 data/session.json
+.nia/security/
+*.jsonl
+.venv/

--- a/.nia_config.json
+++ b/.nia_config.json
@@ -41,5 +41,5 @@
     }
   },
   "project_prompt": "prompt",
-  "created_at": "2026-02-07T14:08:03Z"
+  "created_at": "2026-02-09T18:35:28Z"
 }

--- a/NIA_PROMPT.md
+++ b/NIA_PROMPT.md
@@ -56,6 +56,32 @@ project/
 
 ---
 
+## 🚨 CRITICAL JSON FORMAT REQUIREMENTS
+
+**Your response MUST be valid JSON. Common mistakes to AVOID:**
+
+```json
+// ❌ WRONG - Template literals (backticks):
+{
+  "path": "index.html",
+  "content": `<!DOCTYPE html>...</html>`
+}
+
+// ✅ CORRECT - JSON strings (double quotes):
+{
+  "path": "index.html",
+  "content": "<!DOCTYPE html>...</html>"
+}
+```
+
+**Rules:**
+1. Use DOUBLE QUOTES `"` for all strings.
+2. NO backticks `` ` `` (those are JavaScript, not JSON).
+3. Escape special characters: `\n` for newlines, `\"` for quotes, `\\` for backslashes.
+4. NO trailing commas.
+
+---
+
 ## 🚨 CRITICAL ERRORS TO AVOID
 
 ### ❌ ERROR #1: Tests in Wrong Location

--- a/src/core/nia_claude_client.py
+++ b/src/core/nia_claude_client.py
@@ -26,6 +26,30 @@ class nIAResponse:
         self.test_file = self._identify_test_file()
         self.test_name: Optional[str] = self._identify_test_name()
 
+    def _sanitize_llm_json(self, raw_response: str) -> str:
+        """Fix common JSON formatting errors from LLM, like template literals."""
+        import re
+
+        # Fix template literals (backticks) -> JSON strings for specific keys
+        def fix_backtick_content(match):
+            key = match.group(1)
+            content = match.group(2)
+            # Escape backslashes first, then quotes
+            content = content.replace('\\', '\\\\').replace('"', '\\"')
+            # Replace actual newlines with \n
+            content = content.replace('\n', '\\n').replace('\r', '')
+            return f'"{key}": "{content}"'
+
+        # Pattern: "key": `value`
+        sanitized = re.sub(
+            r'"(content|path|File)"\s*:\s*`([^`]*)`',
+            fix_backtick_content,
+            raw_response,
+            flags=re.DOTALL
+        )
+
+        return sanitized
+
     def _detect_response_format(self, text: str) -> str:
         """Detect if response is Gemini markdown or Ollama JSON."""
         # Try to extract JSON first
@@ -165,7 +189,10 @@ class nIAResponse:
 
         logging.info("--- Starting Universal File Parsing ---")
 
-        # 0. Pre-processing: If the whole response is one big code block, strip it
+        # 0. Pre-processing: Fix common JSON errors like backticks
+        text = self._sanitize_llm_json(text)
+
+        # 0.1. If the whole response is one big code block, strip it
         stripped_text = text.strip()
         if stripped_text.startswith('```') and stripped_text.endswith('```'):
             if stripped_text.count('File:') > 1 or stripped_text.count('Archivo:') > 1:

--- a/src/core/robust_parser.py
+++ b/src/core/robust_parser.py
@@ -86,7 +86,25 @@ class RobustJSONParser:
 
         json_str = re.sub(r'\\([^"\\/bfnrtu])', fix_backslash, json_str)
 
-        # 2. Handle literal newlines and tabs inside strings
+        # 2. Fix template literals (backticks) -> JSON strings for specific keys
+        def fix_backtick_content(match):
+            key = match.group(1)
+            content = match.group(2)
+            # Escape backslashes first, then quotes
+            content = content.replace('\\', '\\\\').replace('"', '\\"')
+            # Replace actual newlines with \n
+            content = content.replace('\n', '\\n').replace('\r', '')
+            return f'"{key}": "{content}"'
+
+        # Pattern: "key": `value`
+        json_str = re.sub(
+            r'"(content|path|File)"\s*:\s*`([^`]*)`',
+            fix_backtick_content,
+            json_str,
+            flags=re.DOTALL
+        )
+
+        # 3. Handle literal newlines and tabs inside strings
         # This is trickier because we need to distinguish between newlines in strings vs between keys
         # A simple heuristic: if a newline is followed by something that doesn't look like a key or end of object,
         # it might be inside a string. But that's risky.


### PR DESCRIPTION
This PR fixes a critical issue where the system would freeze or fail when the LLM generated invalid JSON using JavaScript template literals (backticks) instead of double quotes. 

The fix implements a sanitization layer that detects backticks for specific keys and converts them to valid JSON strings, properly escaping internal quotes, backslashes, and newlines. 

Additionally, the system prompt has been updated to explicitly forbid backticks in JSON responses. 

Verification was performed using a reproduction script and the existing unit test suite. All tests passed after restoring the project to a clean state.

---
*PR created automatically by Jules for task [17101203183080492078](https://jules.google.com/task/17101203183080492078) started by @Axlfc*