### PR TITLE
Allow tests/ and test_data/ in project structure and implement auto-correction

### DIFF
--- a/.nia_config.json
+++ b/.nia_config.json
@@ -41,5 +41,5 @@
     }
   },
   "project_prompt": "prompt",
-  "created_at": "2026-02-09T19:49:36Z"
+  "created_at": "2026-02-11T15:47:30Z"
 }

--- a/NIA_PROMPT.md
+++ b/NIA_PROMPT.md
@@ -1,42 +1,5 @@
 # 🤖 nIA Agent - Autonomous TDD Loop
 
-## 🚨 ABSOLUTE REQUIREMENTS - READ FIRST
-
-### FORBIDDEN: Placeholder Code
-
-**You must NEVER generate:**
-- Ellipsis placeholders: `...`
-- TODO comments: `// TODO: implement`
-- Empty HTML comments: `<!-- Content here -->`
-- Incomplete functions or blocks
-
-### REQUIRED: Complete, Functional Code
-
-**Every line of code you generate must be:**
-- Complete and executable
-- Functional (no placeholders)
-- Real content (not comments about content)
-
-**Example - WRONG:**
-```javascript
-function init() {
-  ... // Placeholder - FORBIDDEN
-}
-```
-
-**Example - CORRECT:**
-```javascript
-function init() {
-  const nav = document.querySelector('nav');
-  nav.addEventListener('click', handleNav);
-  console.log('App initialized');
-}
-```
-
-**If asked for "minimum 100 lines", generate 100 lines of REAL code, not TODOs.**
-
----
-
 # CRITICAL: File Structure Rules by Tech Stack
 
 You are working on a `` project. Follow these EXACT structure rules:
@@ -92,67 +55,6 @@ project/
 ```
 
 ---
-
-## 🚨 CRITICAL JSON FORMAT REQUIREMENTS
-
-**Your response MUST be valid JSON. Common mistakes to AVOID:**
-
-```json
-// ❌ WRONG - Template literals (backticks):
-{
-  "path": "index.html",
-  "content": `<!DOCTYPE html>...</html>`
-}
-
-// ✅ CORRECT - JSON strings (double quotes):
-{
-  "path": "index.html",
-  "content": "<!DOCTYPE html>...</html>"
-}
-```
-
-**Rules:**
-1. Use DOUBLE QUOTES `"` for all strings.
-2. NO backticks `` ` `` (those are JavaScript, not JSON).
-3. Escape special characters: `\n` for newlines, `\"` for quotes, `\\` for backslashes.
-4. NO trailing commas.
-
----
-
-## 🧪 TEST FILE REQUIREMENTS
-
-### Safe Attribute Access in BeautifulSoup
-
-**ALWAYS use `.get()` when accessing HTML attributes** to avoid KeyError:
-
-```python
-# ❌ WRONG - Will crash if attribute missing:
-if link['id'] in nav_links:
-    pass
-
-# ✅ CORRECT - Safe attribute access:
-if link.get('id') in nav_links:
-    pass
-
-# ✅ ALSO CORRECT - With default value:
-link_id = link.get('id', '')
-if link_id in nav_links:
-    pass
-```
-
-**Remember**: Not all HTML elements have all attributes. Always use `.get()` for safe access.
-
-### Path Resolution in Tests
-
-**ALWAYS use paths relative to the project root.** Tests are executed from the project root directory.
-
-```python
-# ❌ WRONG - Assuming execution from tests/ folder:
-HTML_FILE = '../index.html'
-
-# ✅ CORRECT - Relative to project root:
-HTML_FILE = 'index.html'
-```
 
 ## 🚨 CRITICAL ERRORS TO AVOID
 

--- a/nia_metrics.json
+++ b/nia_metrics.json
@@ -1,9 +1,9 @@
 {
   "project_id": ".",
-  "created_at": "2026-02-09T19:49:36Z",
+  "created_at": "2026-02-11T15:47:33Z",
   "plan_review": {
     "iterations": 1,
-    "approval_time_seconds": 0.0004582405090332031,
+    "approval_time_seconds": 0.0007338523864746094,
     "final_approved": false,
     "issues_found": [
       "Error parsing AI response: Expecting value: line 1 column 1 (char 0)"
@@ -12,12 +12,12 @@
   "dependencies": {
     "requirements_generated": true,
     "auto_detected": [
+      "tkinter",
+      "shutil",
       "typer",
+      "customtkinter",
       "uuid",
       "yaml",
-      "tkinter",
-      "customtkinter",
-      "shutil",
       "src",
       "bs4",
       "beautifulsoup4",

--- a/src/core/file_structure_validator.py
+++ b/src/core/file_structure_validator.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 class FileStructureValidator:
     """
-    Valida i auto-corregeix estructures de fitxers segons tech_stack.
+    Validates and auto-corrects file structures according to tech_stack.
 
     If no tech_stack is provided, it defaults to 'frontend_web'.
     """
@@ -14,6 +14,7 @@ class FileStructureValidator:
     STRUCTURE_RULES = {
         "_base": {
             "tests": r"^tests/.*\.py$",
+            "test_data": r"^test_data/.*",
             "config": r"^[\w.-]+\.(json|md|txt|yaml|yml|ini|toml)$",
             "gitkeep": r"^.*\.gitkeep$",
             "gitignore": r"^\.gitignore$",
@@ -21,14 +22,16 @@ class FileStructureValidator:
             "requirements": r"^requirements\.txt$"
         },
         "frontend_web": {
-            "html": r"^(?!project/|src/|public/|assets/|tests/|css/|js/)[\w-]+\.html$",  # Root level only
+            "html": r"^(?!project/|src/|public/|assets/|tests/|test_data/|css/|js/)[\w-]+\.html$",  # Root level only
             "css": r"^css/.*\.css$",
             "js": r"^js/.*\.js$",
-            "assets": r"^assets/.*"
+            "assets": r"^assets/.*",
+            "test_data": r"^test_data/.*"
         },
         "backend_python": {
             "python": r"^[\w/]+\.py$",
-            "requirements": r"^requirements\.txt$"
+            "requirements": r"^requirements\.txt$",
+            "test_data": r"^test_data/.*"
         }
     }
 
@@ -36,10 +39,11 @@ class FileStructureValidator:
 
     def __init__(self, issue_manager=None):
         self.issue_manager = issue_manager
+        self.metrics = {"auto_corrections": 0}
 
     def validate_and_fix(self, files: List[Dict], tech_stack: Optional[str] = None) -> Tuple[List[Dict], List[str]]:
         """
-        Valida fitxers i intenta auto-corregir paths incorrectes.
+        Validates files and attempts to auto-correct common incorrect paths.
 
         Returns:
             (fixed_files, warnings)
@@ -58,8 +62,10 @@ class FileStructureValidator:
             if fixed_path != original_path:
                 warning = f"Auto-fixed path: {original_path} → {fixed_path}"
                 warnings.append(warning)
+                self.metrics["auto_corrections"] += 1
+                logger.warning(f"⚠️ Auto-corrected path: {original_path} → {fixed_path}")
 
-                # Crear issue si tenim IssueManager
+                # Create issue if we have an IssueManager
                 if self.issue_manager:
                     self.issue_manager.create_issue(
                         title=f"Invalid file path auto-corrected: {original_path}",
@@ -80,7 +86,7 @@ class FileStructureValidator:
         return fixed_files, warnings
 
     def is_valid(self, path: str, tech_stack: str) -> bool:
-        """Comprova si un path és vàlid per al tech_stack donat"""
+        """Checks if a path is valid for the given tech_stack"""
 
         # 1. Check base rules first (apply to all stacks)
         base_rules = self.STRUCTURE_RULES.get("_base", {})
@@ -103,32 +109,38 @@ class FileStructureValidator:
         return False
 
     def _auto_fix_path(self, path: str, tech_stack: str) -> str:
-        """Intenta corregir automàticament paths comuns incorrectes"""
+        """Attempts to automatically fix common incorrect paths"""
         # Strip common wrong prefixes
         for prefix in self.COMMON_PREFIXES_TO_STRIP:
             if path.startswith(prefix):
                 path = path[len(prefix):]
 
-        # Validar segons tech_stack
+        # Normalize .tests/ or test/ to tests/
+        if path.startswith('.tests/'):
+            path = path.replace('.tests/', 'tests/', 1)
+        elif path.startswith('test/') and not path.startswith('tests/'):
+            path = path.replace('test/', 'tests/', 1)
+
+        # Validate according to tech_stack
         if tech_stack == "frontend_web":
-            # Assegurar que CSS va a css/
-            if path.endswith('.css') and not path.startswith('css/'):
+            # Ensure CSS goes to css/ (unless it's test_data or tests)
+            if path.endswith('.css') and not any(path.startswith(d) for d in ['css/', 'test_data/', 'tests/']):
                 path = f"css/{path}"
 
-            # Assegurar que JS va a js/
-            if path.endswith('.js') and not path.startswith('js/'):
+            # Ensure JS goes to js/ (unless it's test_data or tests)
+            if path.endswith('.js') and not any(path.startswith(d) for d in ['js/', 'test_data/', 'tests/']):
                 path = f"js/{path}"
 
-            # Assegurar que HTML va a root (si estava en algun subfolder que hem stripat o si l'AI ho ha posat malament)
-            if path.endswith('.html'):
-                # Si encara té '/' vol dir que està en un subdir no stripat
+            # Ensure HTML goes to root (unless it's test_data or tests)
+            if path.endswith('.html') and not any(path.startswith(d) for d in ['test_data/', 'tests/']):
+                # If it still has '/' it means it's in an unstripped subdir
                 if '/' in path:
                     path = path.split('/')[-1]
 
         return path
 
     def generate_structure_guide(self, tech_stack: str) -> str:
-        """Genera una guia clara d'estructura per incluir en prompts"""
+        """Generates a clear structure guide to include in prompts"""
         guides = {
             "frontend_web": """
 ## CRITICAL: Frontend Web Structure Rules

--- a/src/templates/NIA_PROMPT.md.jinja2
+++ b/src/templates/NIA_PROMPT.md.jinja2
@@ -38,10 +38,97 @@ IMPORTANT:
 3. ❌ Using relative paths like `./css/style.css` instead of `css/style.css`
 
 ## ✅ What Happens if You Make Mistakes:
-- The system will AUTO-CORRECT common path errors
+- The system will AUTO-CORRECT common path errors (like `.tests/` to `tests/`)
 - An issue will be logged in `.nia/issues.db`
 - You will receive feedback in the next iteration
 - The Troubleshooting Wiki will be updated
+
+### What Happens If You Use Wrong Path?
+
+**The system will auto-correct it:**
+
+```python
+# You write:
+{"path": ".tests/test_menu.py", "content": "..."}
+
+# System auto-corrects to:
+# ⚠️ Auto-corrected: .tests/test_menu.py → tests/test_menu.py
+
+# File is saved at: tests/test_menu.py
+```
+
+**To avoid warnings, always use `tests/` from the start.**
+
+## 🧪 TEST FILE REQUIREMENTS
+
+### Test File Location
+
+**Tests MUST be in the `tests/` directory**:
+
+```
+✅ CORRECT Structure:
+project/
+├── index.html
+├── css/
+├── js/
+└── tests/              ← All tests here
+    ├── test_html.py
+    └── test_menu.py
+```
+
+### ⚠️ MORE COMMON MISTAKES - AVOID THESE
+
+**1. Wrong directory name:**
+```
+❌ WRONG: .tests/test_menu.py      (dot prefix - will be auto-corrected)
+❌ WRONG: test/test_menu.py         (singular - not allowed)
+❌ WRONG: __tests__/test_menu.py    (JS convention - not allowed)
+
+✅ CORRECT: tests/test_menu.py
+```
+
+**2. Wrong file location:**
+```
+❌ WRONG: test_menu.py              (at root)
+❌ WRONG: js/tests/test_menu.py     (inside code directory)
+
+✅ CORRECT: tests/test_menu.py      (in tests/ directory)
+```
+
+**3. Test data location:**
+```
+❌ WRONG: tests/data/sample.html    (inside tests/)
+❌ WRONG: data/sample.html          (generic name)
+
+✅ CORRECT: test_data/sample.html   (separate directory)
+```
+
+### Test Data Files
+
+If your tests need sample HTML/CSS/JSON files:
+
+```
+✅ CORRECT Structure:
+project/
+├── tests/
+│   ├── test_html.py           ← Test code
+│   └── test_menu.py
+└── test_data/                 ← Test fixtures
+    ├── sample.html
+    ├── sample.css
+    └── test_config.json
+```
+
+**In your test code:**
+```python
+# ✅ CORRECT: Reference test_data/ from project root
+with open('test_data/sample.html', 'r') as f:
+    html = f.read()
+
+# ❌ WRONG: Don't use absolute paths
+with open('/tests/data/sample.html', 'r') as f:
+    pass
+```
 
 ## 🎯 To Avoid Issues:
 Always double-check your file paths match the structure above BEFORE generating code.


### PR DESCRIPTION
This change resolves the critical issue where test files were being blocked by the project structure validator when placed in `.tests/`. It implements an auto-correction mechanism that transparently moves files from `.tests/` or `test/` to the standard `tests/` directory, while also allowing a `test_data/` directory for fixtures. The AI prompt has been significantly improved to guide the agent toward the correct structure and explain the auto-correction behavior. logic was carefully tuned to ensure files inside `tests/` or `test_data/` are not incorrectly moved by tech-stack-specific rules (e.g., keeping `.js` helpers in `tests/` instead of moving them to `js/`).

---
*PR created automatically by Jules for task [7461496175443312441](https://jules.google.com/task/7461496175443312441) started by @Axlfc*